### PR TITLE
Supports configurable domain name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,15 +33,15 @@ Deployment
 ==========
 
 Assuming your external network is called ``ext_net``, your SSH key is
-``default`` and your CentOS 7.1 image is ``centos71``, this is how you
-deploy OpenShift:
+``default``, your CentOS 7.1 image is ``centos71`` and your domain
+name is ``example.com``, this is how you deploy OpenShift:
 
 ::
 
    git clone https://github.com/redhat-openstack/openshift-on-openstack.git
    heat stack-create my_openshift -f openshift-on-openstack/openshift.yaml \
        -P server_image=centos71 -P external_network=ext_net \
-       -P ssh_key_name=default -P node_count=2
+       -P ssh_key_name=default -P domain_name=example.com -P node_count=2
 
 The ``node_count`` parameter specifies how many non-master OpenShift nodes you
 want to deploy. In the example above, we will deploy one master and two nodes.

--- a/dns.yaml
+++ b/dns.yaml
@@ -49,7 +49,7 @@ parameters:
   node_etc_hosts:
     type: string
 
-  domainname:
+  domain_name:
     type: string
 
   floating_ip:
@@ -72,7 +72,7 @@ resources:
           template: "HOST.DOMAIN"
           params:
             HOST: {get_param: hostname}
-            DOMAIN: {get_param: domainname}
+            DOMAIN: {get_param: domain_name}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
       flavor: {get_param: flavor}
@@ -100,7 +100,7 @@ resources:
             template: "HOST.DOMAIN"
             params:
               HOST: {get_param: hostname}
-              DOMAIN: {get_param: domainname}
+              DOMAIN: {get_param: domain_name}
 
   included_files:
     type: OS::Heat::CloudConfig
@@ -113,7 +113,7 @@ resources:
               params:
                 $NODE_IP: {get_param: floating_ip}
                 $NODE_HOSTNAME: {get_param: hostname}
-                $NODE_DOMAIN: {get_param: domainname}
+                $NODE_DOMAIN: {get_param: domain_name}
                 $MASTER_IP: {get_param: master_ip_address}
                 $MASTER_HOSTNAME: {get_param: master_hostname}
                 $NODE_ETC_HOSTS: {get_param: node_etc_hosts}
@@ -124,7 +124,7 @@ resources:
             str_replace:
               params:
                 $MASTER_IP: {get_param: master_ip_address}
-                $DOMAINNAME: {get_param: domainname}
+                $DOMAINNAME: {get_param: domain_name}
               template: {get_file: fragments/dnsmasq.conf}
         - path: /usr/bin/retry
           permissions: 0755

--- a/dns.yaml
+++ b/dns.yaml
@@ -37,13 +37,22 @@ parameters:
     constraints:
     - custom_constraint: neutron.subnet
 
+  hostname:
+    type: string
+
   master_ip_address:
     type: string
 
   master_hostname:
     type: string
 
+  node_etc_hosts:
+    type: string
+
   domainname:
+    type: string
+
+  floating_ip:
     type: string
 
   port:
@@ -58,6 +67,12 @@ resources:
   host:
     type: OS::Nova::Server
     properties:
+      name:
+        str_replace:
+          template: "HOST.DOMAIN"
+          params:
+            HOST: {get_param: hostname}
+            DOMAIN: {get_param: domainname}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
       flavor: {get_param: flavor}
@@ -71,8 +86,21 @@ resources:
     type: OS::Heat::MultipartMime
     properties:
       parts:
+      - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
       - config: {get_resource: boot_config}
+
+  set_hostname:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        hostname: {get_param: hostname}
+        fqdn:
+          str_replace:
+            template: "HOST.DOMAIN"
+            params:
+              HOST: {get_param: hostname}
+              DOMAIN: {get_param: domainname}
 
   included_files:
     type: OS::Heat::CloudConfig
@@ -83,9 +111,12 @@ resources:
           content:
             str_replace:
               params:
+                $NODE_IP: {get_param: floating_ip}
+                $NODE_HOSTNAME: {get_param: hostname}
+                $NODE_DOMAIN: {get_param: domainname}
                 $MASTER_IP: {get_param: master_ip_address}
                 $MASTER_HOSTNAME: {get_param: master_hostname}
-                $DOMAINNAME: {get_param: domainname}
+                $NODE_ETC_HOSTS: {get_param: node_etc_hosts}
               template:
                 {get_file: fragments/etc-hosts}
         - path: /root/dnsmasq.conf

--- a/dns.yaml
+++ b/dns.yaml
@@ -43,6 +43,9 @@ parameters:
   master_hostname:
     type: string
 
+  domainname:
+    type: string
+
   port:
     description: Neutron port (with a floating IP address) to assign to the DNS Nova Server
     type: string
@@ -82,6 +85,7 @@ resources:
               params:
                 $MASTER_IP: {get_param: master_ip_address}
                 $MASTER_HOSTNAME: {get_param: master_hostname}
+                $DOMAINNAME: {get_param: domainname}
               template:
                 {get_file: fragments/etc-hosts}
         - path: /root/dnsmasq.conf
@@ -89,6 +93,7 @@ resources:
             str_replace:
               params:
                 $MASTER_IP: {get_param: master_ip_address}
+                $DOMAINNAME: {get_param: domainname}
               template: {get_file: fragments/dnsmasq.conf}
         - path: /usr/bin/retry
           permissions: 0755

--- a/fragments/ansible-inventory
+++ b/fragments/ansible-inventory
@@ -13,13 +13,13 @@ ansible_sudo=true
 deployment_type=origin
 
 openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/openshift/openshift-passwd'}]
-osm_default_subdomain=cloudapps.example.com
+osm_default_subdomain=cloudapps.$DOMAINNAME
 
 # host group for masters
 [masters]
-$MASTER_HOSTNAME
+$MASTER_HOSTNAME.$DOMAINNAME
 
 # host group for nodes
 [nodes]
-$MASTER_HOSTNAME openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+$MASTER_HOSTNAME.$DOMAINNAME openshift_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshit_public_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 $NODE_HOSTNAMES

--- a/fragments/ansible-inventory
+++ b/fragments/ansible-inventory
@@ -17,7 +17,7 @@ osm_default_subdomain=cloudapps.$DOMAINNAME
 
 # host group for masters
 [masters]
-$MASTER_HOSTNAME.$DOMAINNAME openshift_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshit_public_hostname=$MASTER_HOSTNAME.$DOMAINNAME
+$MASTER_HOSTNAME.$DOMAINNAME openshift_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshit_public_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshift_master_public_console_url=https://$MASTER_HOSTNAME.$DOMAINNAME:8443/console openshift_master_public_api_url=https://$MASTER_HOSTNAME.$DOMAINNAME:8443
 
 # host group for nodes
 [nodes]

--- a/fragments/ansible-inventory
+++ b/fragments/ansible-inventory
@@ -17,7 +17,7 @@ osm_default_subdomain=cloudapps.$DOMAINNAME
 
 # host group for masters
 [masters]
-$MASTER_HOSTNAME.$DOMAINNAME
+$MASTER_HOSTNAME.$DOMAINNAME openshift_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshit_public_hostname=$MASTER_HOSTNAME.$DOMAINNAME
 
 # host group for nodes
 [nodes]

--- a/fragments/dnsmasq.conf
+++ b/fragments/dnsmasq.conf
@@ -1,7 +1,7 @@
 strict-order
 domain-needed
-local=/example.com/
+local=/$DOMAINNAME/
 bind-dynamic
 resolv-file=/etc/resolv.conf
-address=/.cloudapps.example.com/$MASTER_IP
+address=/.cloudapps.$DOMAINNAME/$MASTER_IP
 log-queries

--- a/fragments/etc-hosts
+++ b/fragments/etc-hosts
@@ -1,5 +1,5 @@
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
-$MASTER_IP $MASTER_HOSTNAME
+$MASTER_IP $MASTER_HOSTNAME.$DOMAINNAME $MASTER_HOSTNAME
 $NODE_ETC_HOSTS

--- a/fragments/etc-hosts
+++ b/fragments/etc-hosts
@@ -1,5 +1,6 @@
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
-$MASTER_IP $MASTER_HOSTNAME.$DOMAINNAME $MASTER_HOSTNAME
+$NODE_IP $NODE_HOSTNAME.$NODE_DOMAIN $NODE_HOSTNAME
+$MASTER_IP $MASTER_HOSTNAME.$NODE_DOMAIN $MASTER_HOSTNAME
 $NODE_ETC_HOSTS

--- a/fragments/etc-node-hosts
+++ b/fragments/etc-node-hosts
@@ -1,4 +1,4 @@
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
-$NODE_IP $NODE_HOSTNAME
+$NODE_IP $NODE_HOSTNAME.$NODE_DOMAIN $NODE_HOSTNAME

--- a/fragments/master-boot.sh
+++ b/fragments/master-boot.sh
@@ -27,7 +27,7 @@ retry yum -y install \
 sed -i -e "s/^enabled=1/enabled=0/" /etc/yum.repos.d/epel.repo
 retry yum -y --enablerepo=epel install ansible
 
-
+cd /root/
 git clone "$OPENSHIFT_ANSIBLE_GIT_URL" openshift-ansible
 cd openshift-ansible
 git checkout "$OPENSHIFT_ANSIBLE_GIT_REV"

--- a/master.yaml
+++ b/master.yaml
@@ -61,7 +61,7 @@ parameters:
   hostname:
     type: string
 
-  domainname:
+  domain_name:
     type: string
 
   floating_ip:
@@ -95,7 +95,7 @@ resources:
           template: "HOST.DOMAIN"
           params:
             HOST: {get_param: hostname}
-            DOMAIN: {get_param: domainname}
+            DOMAIN: {get_param: domain_name}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
       flavor: {get_param: flavor}
@@ -124,7 +124,7 @@ resources:
             template: "HOST.DOMAIN"
             params:
               HOST: {get_param: hostname}
-              DOMAIN: {get_param: domainname}
+              DOMAIN: {get_param: domain_name}
 
   included_files:
     type: OS::Heat::CloudConfig
@@ -137,14 +137,14 @@ resources:
               params:
                 $NODE_IP: {get_param: floating_ip}
                 $NODE_HOSTNAME: {get_param: hostname}
-                $NODE_DOMAIN: {get_param: domainname}
+                $NODE_DOMAIN: {get_param: domain_name}
               template: {get_file: fragments/etc-node-hosts}
         - path: /var/lib/ansible-inventory
           content:
             str_replace:
               params:
                 $MASTER_HOSTNAME: {get_param: hostname}
-                $DOMAINNAME: {get_param: domainname}
+                $DOMAINNAME: {get_param: domain_name}
                 $NODE_HOSTNAMES: {get_param: node_hostnames}
                 $SSH_USER: {get_param: ssh_user}
               template: {get_file: fragments/ansible-inventory}
@@ -194,12 +194,12 @@ outputs:
       str_replace:
         params:
           HOSTNAME: {get_param: hostname}
-          DOMAINNAME: {get_param: domainname}
+          DOMAINNAME: {get_param: domain_name}
         template: "https://HOSTNAME.DOMAINNAME:8443/console/"
   api_url:
     value:
       str_replace:
         params:
           HOSTNAME: {get_param: hostname}
-          DOMAINNAME: {get_param: domainname}
+          DOMAINNAME: {get_param: domain_name}
         template: "https://HOSTNAME.DOMAINNAME:8443/"

--- a/master.yaml
+++ b/master.yaml
@@ -76,9 +76,6 @@ parameters:
   node_hostnames:
     type: string
 
-  node_etc_hosts:
-    type: string
-
   ssh_user:
     type: string
 
@@ -129,7 +126,6 @@ resources:
               HOST: {get_param: hostname}
               DOMAIN: {get_param: domainname}
 
-  # TODO: is /etc/hosts necessary? DNS should be providing this.
   included_files:
     type: OS::Heat::CloudConfig
     properties:
@@ -139,11 +135,10 @@ resources:
           content:
             str_replace:
               params:
-                $MASTER_IP: {get_param: floating_ip}
-                $MASTER_HOSTNAME: {get_param: hostname}
-                $DOMAINNAME: {get_param: domainname}
-                $NODE_ETC_HOSTS: {get_param: node_etc_hosts}
-              template: {get_file: fragments/etc-hosts}
+                $NODE_IP: {get_param: floating_ip}
+                $NODE_HOSTNAME: {get_param: hostname}
+                $NODE_DOMAIN: {get_param: domainname}
+              template: {get_file: fragments/etc-node-hosts}
         - path: /var/lib/ansible-inventory
           content:
             str_replace:

--- a/master.yaml
+++ b/master.yaml
@@ -61,6 +61,9 @@ parameters:
   hostname:
     type: string
 
+  domainname:
+    type: string
+
   floating_ip:
     type: string
 
@@ -90,7 +93,12 @@ resources:
   host:
     type: OS::Nova::Server
     properties:
-      name: {get_param: hostname}
+      name:
+        str_replace:
+          template: "HOST.DOMAIN"
+          params:
+            HOST: {get_param: hostname}
+            DOMAIN: {get_param: domainname}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
       flavor: {get_param: flavor}
@@ -114,7 +122,12 @@ resources:
     properties:
       cloud_config:
         hostname: {get_param: hostname}
-        fqdn: {get_param: hostname}
+        fqdn:
+          str_replace:
+            template: "HOST.DOMAIN"
+            params:
+              HOST: {get_param: hostname}
+              DOMAIN: {get_param: domainname}
 
   # TODO: is /etc/hosts necessary? DNS should be providing this.
   included_files:
@@ -128,6 +141,7 @@ resources:
               params:
                 $MASTER_IP: {get_param: floating_ip}
                 $MASTER_HOSTNAME: {get_param: hostname}
+                $DOMAINNAME: {get_param: domainname}
                 $NODE_ETC_HOSTS: {get_param: node_etc_hosts}
               template: {get_file: fragments/etc-hosts}
         - path: /var/lib/ansible-inventory
@@ -135,6 +149,7 @@ resources:
             str_replace:
               params:
                 $MASTER_HOSTNAME: {get_param: hostname}
+                $DOMAINNAME: {get_param: domainname}
                 $NODE_HOSTNAMES: {get_param: node_hostnames}
                 $SSH_USER: {get_param: ssh_user}
               template: {get_file: fragments/ansible-inventory}
@@ -184,10 +199,12 @@ outputs:
       str_replace:
         params:
           HOSTNAME: {get_param: hostname}
-        template: "https://HOSTNAME:8443/console/"
+          DOMAINNAME: {get_param: domainname}
+        template: "https://HOSTNAME.DOMAINNAME:8443/console/"
   api_url:
     value:
       str_replace:
         params:
           HOSTNAME: {get_param: hostname}
-        template: "https://HOSTNAME:8443/"
+          DOMAINNAME: {get_param: domainname}
+        template: "https://HOSTNAME.DOMAINNAME:8443/"

--- a/node.yaml
+++ b/node.yaml
@@ -51,7 +51,7 @@ parameters:
   hostname_prefix:
     type: string
 
-  domainname:
+  domain_name:
     type: string
 
   ansible_public_key:
@@ -77,7 +77,7 @@ resources:
           params:
             HOST: {get_param: hostname_prefix}
             SUFFIX: {get_attr: [random_hostname_suffix, value]}
-            DOMAIN: {get_param: domainname}
+            DOMAIN: {get_param: domain_name}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
       flavor: {get_param: flavor}
@@ -112,7 +112,7 @@ resources:
             params:
               HOST: {get_param: hostname_prefix}
               SUFFIX: {get_attr: [random_hostname_suffix, value]}
-              DOMAIN: {get_param: domainname}
+              DOMAIN: {get_param: domain_name}
 
   included_files:
     type: OS::Heat::CloudConfig
@@ -130,7 +130,7 @@ resources:
                     params:
                       HOST: {get_param: hostname_prefix}
                       SUFFIX: {get_attr: [random_hostname_suffix, value]}
-                $NODE_DOMAIN: {get_param: domainname}
+                $NODE_DOMAIN: {get_param: domain_name}
               template: {get_file: fragments/etc-node-hosts}
         - path: /usr/bin/retry
           permissions: 0755
@@ -195,7 +195,7 @@ outputs:
         params:
           HOST: {get_param: hostname_prefix}
           SUFFIX: {get_attr: [random_hostname_suffix, value]}
-          DOMAIN: {get_param: domainname}
+          DOMAIN: {get_param: domain_name}
   ansible_entry:
     description: Ansible inventory line for this OpenShift node
     value:
@@ -204,7 +204,7 @@ outputs:
         params:
           HOST: {get_param: hostname_prefix}
           SUFFIX: {get_attr: [random_hostname_suffix, value]}
-          DOMAIN: {get_param: domainname}
+          DOMAIN: {get_param: domain_name}
   etc_hosts:
     description: A hostname/IP entry for /etc/hosts
     value:
@@ -214,7 +214,7 @@ outputs:
           IP: {get_attr: [floating_ip, floating_ip_address]}
           HOST: {get_param: hostname_prefix}
           SUFFIX: {get_attr: [random_hostname_suffix, value]}
-          DOMAIN: {get_param: domainname}
+          DOMAIN: {get_param: domain_name}
   ip_address:
     description: IP address of the node
     value: {get_attr: [floating_ip, floating_ip_address]}

--- a/node.yaml
+++ b/node.yaml
@@ -65,6 +65,7 @@ resources:
   random_hostname_suffix:
     type: OS::Heat::RandomString
     properties:
+      character_classes: [{"min": 5, "class": "lowercase"}]
       length: 5
 
   host:
@@ -208,7 +209,7 @@ outputs:
     description: A hostname/IP entry for /etc/hosts
     value:
       str_replace:
-        template: "IP HOST-SUFFIX.DOMAIN"
+        template: "IP HOST-SUFFIX.DOMAIN HOST-SUFFIX"
         params:
           IP: {get_attr: [floating_ip, floating_ip_address]}
           HOST: {get_param: hostname_prefix}

--- a/node.yaml
+++ b/node.yaml
@@ -51,6 +51,9 @@ parameters:
   hostname_prefix:
     type: string
 
+  domainname:
+    type: string
+
   ansible_public_key:
     type: string
 
@@ -69,10 +72,11 @@ resources:
     properties:
       name:
         str_replace:
-          template: "HOST-SUFFIX.example.com"
+          template: "HOST-SUFFIX.DOMAIN"
           params:
             HOST: {get_param: hostname_prefix}
             SUFFIX: {get_attr: [random_hostname_suffix, value]}
+            DOMAIN: {get_param: domainname}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
       flavor: {get_param: flavor}
@@ -97,27 +101,22 @@ resources:
       cloud_config:
         hostname:
           str_replace:
-            template: "HOST-SUFFIX.example.com"
+            template: "HOST-SUFFIX"
             params:
               HOST: {get_param: hostname_prefix}
               SUFFIX: {get_attr: [random_hostname_suffix, value]}
         fqdn:
           str_replace:
-            template: "HOST-SUFFIX.example.com"
+            template: "HOST-SUFFIX.DOMAIN"
             params:
               HOST: {get_param: hostname_prefix}
               SUFFIX: {get_attr: [random_hostname_suffix, value]}
+              DOMAIN: {get_param: domainname}
 
   included_files:
     type: OS::Heat::CloudConfig
     properties:
       cloud_config:
-        write_files:
-        - path: /usr/bin/retry
-          permissions: 0755
-          content: {get_file: fragments/retry.sh}
-        ssh_authorized_keys:
-        - {get_param: ansible_public_key}
         write_files:
         - path: /etc/hosts
           content:
@@ -126,12 +125,17 @@ resources:
                 $NODE_IP: {get_attr: [floating_ip, floating_ip_address]}
                 $NODE_HOSTNAME:
                   str_replace:
-                    template: "HOST-SUFFIX.example.com"
+                    template: "HOST-SUFFIX"
                     params:
                       HOST: {get_param: hostname_prefix}
                       SUFFIX: {get_attr: [random_hostname_suffix, value]}
+                $NODE_DOMAIN: {get_param: domainname}
               template: {get_file: fragments/etc-node-hosts}
-
+        - path: /usr/bin/retry
+          permissions: 0755
+          content: {get_file: fragments/retry.sh}
+        ssh_authorized_keys:
+        - {get_param: ansible_public_key}
   rhn_register:
     type: OS::Heat::SoftwareConfig
     properties:
@@ -186,19 +190,30 @@ outputs:
     description: Hostname of this OpenShift node
     value:
       str_replace:
-        template: "HOST-SUFFIX.example.com"
+        template: "HOST-SUFFIX.DOMAIN"
         params:
           HOST: {get_param: hostname_prefix}
           SUFFIX: {get_attr: [random_hostname_suffix, value]}
+          DOMAIN: {get_param: domainname}
+  ansible_entry:
+    description: Ansible inventory line for this OpenShift node
+    value:
+      str_replace:
+        template: "HOST-SUFFIX.DOMAIN openshift_hostname=HOST-SUFFIX.DOMAIN openshift_public_hostname=HOST-SUFFIX.DOMAIN"
+        params:
+          HOST: {get_param: hostname_prefix}
+          SUFFIX: {get_attr: [random_hostname_suffix, value]}
+          DOMAIN: {get_param: domainname}
   etc_hosts:
     description: A hostname/IP entry for /etc/hosts
     value:
       str_replace:
-        template: "IP HOST-SUFFIX.example.com"
+        template: "IP HOST-SUFFIX.DOMAIN"
         params:
           IP: {get_attr: [floating_ip, floating_ip_address]}
           HOST: {get_param: hostname_prefix}
           SUFFIX: {get_attr: [random_hostname_suffix, value]}
+          DOMAIN: {get_param: domainname}
   ip_address:
     description: IP address of the node
     value: {get_attr: [floating_ip, floating_ip_address]}

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -66,12 +66,23 @@ parameters:
     hidden: true
     default: ''
 
-  master_fqdn:
+  domainname:
     type: string
     description: >
-      The fully qualified domain name that is going to be set as the hostname
-      of the OpenShift master.
-    default: "openshift-master.example.com"
+      The domain name that is going to be used as the base for all hostnames.
+    default: "example.com"
+
+  master_hostname:
+    type: string
+    description: >
+      The hostname that is going to be set for the master.
+    default: "openshift-master"
+
+  node_hostname_prefix:
+    type: string
+    description: >
+      The hostname prefix that is going to be set for the nodes.
+    default: "openshift-node"
 
   ssh_user:
     type: string
@@ -128,7 +139,8 @@ resources:
       fixed_network: {get_resource: fixed_network}
       fixed_subnet: {get_resource: fixed_subnet}
       master_ip_address: {get_attr: [master_floating_ip, floating_ip_address]}
-      master_hostname: {get_param: master_fqdn}
+      master_hostname: {get_param: master_hostname}
+      domainname: {get_param: domainname}
       port: {get_resource: dnsmasq_port}
 
   openshift_master:
@@ -148,7 +160,8 @@ resources:
       rhn_password: {get_param: rhn_password}
       rhn_pool: {get_param: rhn_pool}
       floating_ip: {get_attr: [master_floating_ip, floating_ip_address]}
-      hostname: {get_param: master_fqdn}
+      hostname: {get_param: master_hostname}
+      domainname: {get_param: domainname}
       ansible_public_key: {get_attr: [ansible_keys, public_key]}
       ansible_private_key: {get_attr: [ansible_keys, private_key]}
       openshift_ansible_git_url: {get_param: openshift_ansible_git_url}
@@ -156,7 +169,7 @@ resources:
       node_hostnames:
         list_join:
         - "\n"
-        - {get_attr: [openshift_nodes, outputs_list, hostname]}
+        - {get_attr: [openshift_nodes, outputs_list, ansible_entry]}
       node_etc_hosts:
         list_join:
         - "\n"
@@ -182,7 +195,8 @@ resources:
           fixed_subnet: {get_resource: fixed_subnet}
           rhn_username: {get_param: rhn_username}
           rhn_password: {get_param: rhn_password}
-          hostname_prefix: "openshift-node"
+          hostname_prefix: {get_param: node_hostname_prefix}
+          domainname: {get_param: domainname}
           ansible_public_key: {get_attr: [ansible_keys, public_key]}
 
   dnsmasq_port:

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -72,6 +72,12 @@ parameters:
       The domain name that is going to be used as the base for all hostnames.
     default: "example.com"
 
+  dns_hostname:
+    type: string
+    description: >
+      The hostname that is going to be set for the DNS server.
+    default: "ns"
+
   master_hostname:
     type: string
     description: >
@@ -129,6 +135,7 @@ resources:
       subnet: {get_resource: fixed_subnet}
 
   dns_host:
+    depends_on: [openshift_nodes]
     type: dns.yaml
     properties:
       image: {get_param: server_image}
@@ -138,9 +145,15 @@ resources:
       external_network: {get_param: external_network}
       fixed_network: {get_resource: fixed_network}
       fixed_subnet: {get_resource: fixed_subnet}
+      hostname: {get_param: dns_hostname}
       master_ip_address: {get_attr: [master_floating_ip, floating_ip_address]}
       master_hostname: {get_param: master_hostname}
+      node_etc_hosts:
+        list_join:
+        - "\n"
+        - {get_attr: [openshift_nodes, outputs_list, etc_hosts]}
       domainname: {get_param: domainname}
+      floating_ip: {get_attr: [dnsmasq_floating_ip, floating_ip_address]}
       port: {get_resource: dnsmasq_port}
 
   openshift_master:
@@ -170,10 +183,6 @@ resources:
         list_join:
         - "\n"
         - {get_attr: [openshift_nodes, outputs_list, ansible_entry]}
-      node_etc_hosts:
-        list_join:
-        - "\n"
-        - {get_attr: [openshift_nodes, outputs_list, etc_hosts]}
 
   openshift_nodes:
     depends_on: external_router_interface

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -152,7 +152,7 @@ resources:
         list_join:
         - "\n"
         - {get_attr: [openshift_nodes, outputs_list, etc_hosts]}
-      domainname: {get_param: domain_name}
+      domain_name: {get_param: domain_name}
       floating_ip: {get_attr: [dnsmasq_floating_ip, floating_ip_address]}
       port: {get_resource: dnsmasq_port}
 
@@ -174,7 +174,7 @@ resources:
       rhn_pool: {get_param: rhn_pool}
       floating_ip: {get_attr: [master_floating_ip, floating_ip_address]}
       hostname: {get_param: master_hostname}
-      domainname: {get_param: domain_name}
+      domain_name: {get_param: domain_name}
       ansible_public_key: {get_attr: [ansible_keys, public_key]}
       ansible_private_key: {get_attr: [ansible_keys, private_key]}
       openshift_ansible_git_url: {get_param: openshift_ansible_git_url}
@@ -205,7 +205,7 @@ resources:
           rhn_username: {get_param: rhn_username}
           rhn_password: {get_param: rhn_password}
           hostname_prefix: {get_param: node_hostname_prefix}
-          domainname: {get_param: domain_name}
+          domain_name: {get_param: domain_name}
           ansible_public_key: {get_attr: [ansible_keys, public_key]}
 
   dnsmasq_port:

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -66,7 +66,7 @@ parameters:
     hidden: true
     default: ''
 
-  domainname:
+  domain_name:
     type: string
     description: >
       The domain name that is going to be used as the base for all hostnames.

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -70,7 +70,6 @@ parameters:
     type: string
     description: >
       The domain name that is going to be used as the base for all hostnames.
-    default: "example.com"
 
   dns_hostname:
     type: string


### PR DESCRIPTION
This PR addresses the following issues:
- OpenShift does not start because node domain names are incorrectly set to include .novalocal by the ansible installer. Explicit fqdns are now passed to the inventory file instead.
- the random suffix of OpenShift minions contains upper case characters that do not match the hostname regex check to register in the master. Only lower case characters are now used instead.
- 'retry' couldn't be installed in the nodes due to a duplicate write_files cloud_config option.
- makes the hostnames and global domain name to be configurable through heat parameters.
- the master's hosts file no longer have explicit entries for the nodes, relying on the DNS server for that.
