### PR TITLE
Adds auto-scaling policies

### DIFF
--- a/dns.yaml
+++ b/dns.yaml
@@ -164,19 +164,33 @@ resources:
             $POOL_ID: {get_param: rhn_pool}
           template: {get_file: fragments/rhn-register.sh}
 
-  node_hosts:
+  node_add:
     type: OS::Heat::SoftwareConfig
     properties:
       group: script
       inputs:
-      - name: node_etc_hosts
+      - name: node_etc_host
       outputs:
       - name: result
       config: |
         #!/bin/sh -x
         echo "Writing to /etc/hosts"
-        sed -i 's/.* #openshift//' /etc/hosts
-        echo "$node_etc_hosts" >> /etc/hosts
+        #sed -i 's/.* #openshift//' /etc/hosts
+        echo "$node_etc_host" >> /etc/hosts
+        systemctl restart dnsmasq
+
+  node_cleanup:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      inputs:
+      - name: node_name
+      outputs:
+      - name: result
+      config: |
+        #!/bin/sh -x
+        cp /etc/hosts /etc/hosts.bkp
+        grep -v "$node_name" /etc/hosts.bkp > /etc/hosts
         systemctl restart dnsmasq
 
   boot_config:

--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -5,6 +5,8 @@ set -eu
 set -x
 set -o pipefail
 
+echo $NODE_HOSTNAME >> /var/lib/openshift_nodes
+
 export HOME=/root
 cat << EOF > /var/lib/ansible-inventory
 # Create an OSEv3 group that contains the masters and nodes groups
@@ -48,17 +50,35 @@ $MASTER_HOSTNAME.$DOMAINNAME openshift_hostname=$MASTER_HOSTNAME.$DOMAINNAME ope
 $MASTER_HOSTNAME.$DOMAINNAME openshift_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshift_public_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 EOF
 
+# this script is triggered for each node being added, let's
+# give all nodes some time to write their hostnames into the list (this
+# minimizes number of ansible-playbook re-runs)
+sleep 60
+
 # Write each node
-for node in $NODE_HOSTNAMES
-do
+for node in `cat /var/lib/openshift_nodes`;do
   #echo "$node" >> /var/lib/ansible-inventory
   echo "$node openshift_hostname=$node openshift_public_hostname=$node openshift_node_labels=\"{'region': 'primary', 'zone': 'default'}\"" >> /var/lib/ansible-inventory
 done
 
+while pidof -x /bin/ansible-playbook; do
+  echo "waiting for another ansible-playbook to finish"
+  sleep 10
+done
+
+if [ -e /var/lib/ansible-inventory.deployed ] && diff /var/lib/ansible-inventory /var/lib/ansible-inventory.deployed; then
+    echo "inventory file has not changed since last ansible run, no need to re-run"
+    exit 0
+fi
+
+cp /var/lib/ansible-inventory /var/lib/ansible-inventory.started
+
 # NOTE: docker-storage-setup hangs during cloud-init because systemd file is set
 # to run after cloud-final.  Temporarily move out of the way (as we've already done storage setup
-mv /usr/lib/systemd/system/docker-storage-setup.service $HOME
-systemctl daemon-reload
+if [ -e /usr/lib/systemd/system/docker-storage-setup.service ]; then
+    mv /usr/lib/systemd/system/docker-storage-setup.service $HOME
+    systemctl daemon-reload
+fi
 
 # NOTE: Ignore the known_hosts check/propmt for now:
 export ANSIBLE_HOST_KEY_CHECKING=False
@@ -67,3 +87,5 @@ ansible-playbook --inventory /var/lib/ansible-inventory $HOME/openshift-ansible/
 # Move docker-storage-setup unit file back in place
 mv $HOME/docker-storage-setup.service /usr/lib/systemd/system
 systemctl daemon-reload
+
+mv /var/lib/ansible-inventory.started /var/lib/ansible-inventory.deployed

--- a/master.yaml
+++ b/master.yaml
@@ -218,13 +218,13 @@ resources:
     properties:
       group: script
       inputs:
-        - name: node_hostnames
+        - name: node_hostname
       config:
         str_replace:
           params:
             $MASTER_HOSTNAME: {get_param: hostname}
             $DOMAINNAME: {get_param: domain_name}
-            $NODE_HOSTNAMES: $node_hostnames
+            $NODE_HOSTNAME: $node_hostname
             $SSH_USER: {get_param: ssh_user}
             $DEPLOYMENT_TYPE: {get_param: deployment_type}
           template: {get_file: fragments/master-ansible.sh}

--- a/node.yaml
+++ b/node.yaml
@@ -75,10 +75,29 @@ parameters:
     type: string
     default: ''
 
+  master_run_ansible:
+    type: string
+    default: ''
+
+  dns_node:
+    type: string
+    default: ''
+
+  dns_node_add:
+    type: string
+    default: ''
+
+  dns_node_cleanup:
+    type: string
+    default: ''
+
   timeout:
     description: Time to wait until the master setup is ready.
     type: number
     default: 4000
+
+  metadata:
+    type: json
 
 resources:
 
@@ -106,6 +125,7 @@ resources:
       - port: {get_resource: port}
       user_data_format: SOFTWARE_CONFIG
       user_data: {get_resource: init}
+      metadata: {get_param: metadata}
 
   docker_volume:
     type: OS::Cinder::Volume
@@ -219,7 +239,7 @@ resources:
       floating_network: {get_param: external_network}
       port_id: {get_resource: port}
 
-  node_cleanup:
+  master_node_cleanup:
     type: OS::Heat::SoftwareConfig
     properties:
       group: script
@@ -230,9 +250,11 @@ resources:
       config: |
         #!/bin/bash -x
         oc --config ~/.kube/config delete node "$node_name"
+        cp /var/lib/openshift_nodes /var/lib/openshift_nodes.bkp
+        grep -v "$node_name" /var/lib/openshift_nodes.bkp > /var/lib/openshift_nodes
         echo "Deleted node $node_name"
 
-  deployment_node_cleanup:
+  deployment_master_node_cleanup:
     type: OS::Heat::SoftwareDeployment
     properties:
       actions: ['DELETE']
@@ -245,9 +267,60 @@ resources:
               SUFFIX: {get_attr: [random_hostname_suffix, value]}
               DOMAIN: {get_param: domain_name}
       config:
-        get_resource: node_cleanup
+        get_resource: master_node_cleanup
       server:
         get_param: master_node
+
+  deployment_dns_node_cleanup:
+    type: OS::Heat::SoftwareDeployment
+    properties:
+      actions: ['DELETE']
+      input_values:
+        node_name:
+          str_replace:
+            template: "HOST-SUFFIX.DOMAIN"
+            params:
+              HOST: {get_param: hostname_prefix}
+              SUFFIX: {get_attr: [random_hostname_suffix, value]}
+              DOMAIN: {get_param: domain_name}
+      config:
+        get_param: dns_node_cleanup
+      server:
+        get_param: dns_node
+
+  deployment_dns_node_add:
+    type: OS::Heat::SoftwareDeployment
+    properties:
+      config:
+        get_param: dns_node_add
+      server:
+        get_param: dns_node
+      input_values:
+        node_etc_host:
+          str_replace:
+              template: "IP HOST-SUFFIX.DOMAIN HOST-SUFFIX #openshift"
+              params:
+                IP: {get_attr: [floating_ip, floating_ip_address]}
+                HOST: {get_param: hostname_prefix}
+                SUFFIX: {get_attr: [random_hostname_suffix, value]}
+                DOMAIN: {get_param: domain_name}
+
+  deployment_run_ansible:
+    depends_on: deployment_dns_node_add
+    type: OS::Heat::SoftwareDeployment
+    properties:
+      config:
+        get_param: master_run_ansible
+      server:
+        get_param: master_node
+      input_values:
+        node_hostname:
+          str_replace:
+            template: "HOST-SUFFIX.DOMAIN"
+            params:
+              HOST: {get_param: hostname_prefix}
+              SUFFIX: {get_attr: [random_hostname_suffix, value]}
+              DOMAIN: {get_param: domain_name}
 
   wait_condition:
     type: OS::Heat::WaitCondition

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -129,6 +129,24 @@ parameters:
     # Known working version on Centos 7 + Origin:
     default: "8f6c6824073dff0cea3cd793db2745fb6cf52931"
 
+  autoscaling:
+    type: boolean
+    description: >
+      Automatically scale up/down openshift nodes.
+    default: false
+
+  openshift_nodes_min:
+    type: number
+    description: >
+      Minimum number of openshift nodes if autoscaling is enabled.
+    default: 1
+
+  openshift_nodes_max:
+    type: number
+    description: >
+      Maximum number of openshift nodes if autoscaling is enabled.
+    default: 5
+
 resources:
 
   fixed_network:
@@ -205,8 +223,8 @@ resources:
     type: OS::Heat::AutoScalingGroup
     properties:
       desired_capacity: {get_param: node_count}
-      min_size: 0
-      max_size: 100
+      min_size: {get_param: openshift_nodes_min}
+      max_size: {get_param: openshift_nodes_max}
       resource:
         type: node.yaml
         properties:
@@ -226,6 +244,55 @@ resources:
           domain_name: {get_param: domain_name}
           ansible_public_key: {get_attr: [ansible_keys, public_key]}
           master_node: {get_attr: [openshift_master, resource.host]}
+          master_run_ansible: {get_attr: [openshift_master, resource.run_ansible]}
+          dns_node: {get_attr: [dns_host, resource.host]}
+          dns_node_cleanup: {get_attr: [dns_host, resource.node_cleanup]}
+          dns_node_add: {get_attr: [dns_host, resource.node_add]}
+          metadata: {"metering.stack": {get_param: "OS::stack_id"}}
+
+  scale_up_policy:
+    type: OS::Heat::ScalingPolicy
+    properties:
+      adjustment_type: change_in_capacity
+      auto_scaling_group_id: {get_resource: openshift_nodes}
+      cooldown: 60
+      scaling_adjustment: 1
+
+  scale_down_policy:
+    type: OS::Heat::ScalingPolicy
+    properties:
+      adjustment_type: change_in_capacity
+      auto_scaling_group_id: {get_resource: openshift_nodes}
+      cooldown: 60
+      scaling_adjustment: '-1'
+
+  cpu_alarm_high:
+    type: OS::Ceilometer::Alarm
+    properties:
+      meter_name: cpu_util
+      statistic: avg
+      period: 60
+      evaluation_periods: 1
+      threshold: 50
+      enabled: {get_param: autoscaling}
+      alarm_actions:
+        - {get_attr: [scale_up_policy, alarm_url]}
+      matching_metadata: {'metadata.user_metadata.stack': {get_param: "OS::stack_id"}}
+      comparison_operator: gt
+
+  cpu_alarm_low:
+    type: OS::Ceilometer::Alarm
+    properties:
+      meter_name: cpu_util
+      statistic: avg
+      period: 600
+      evaluation_periods: 1
+      threshold: 15
+      enabled: {get_param: autoscaling}
+      alarm_actions:
+        - {get_attr: [scale_down_policy, alarm_url]}
+      matching_metadata: {'metadata.user_metadata.stack': {get_param: "OS::stack_id"}}
+      comparison_operator: lt
 
   dnsmasq_port:
     type: OS::Neutron::Port
@@ -297,34 +364,6 @@ resources:
             STACK: {get_param: "OS::stack_id"}
       save_private_key: True
 
-  deployment_node_hosts:
-    type: OS::Heat::SoftwareDeployment
-    properties:
-      config:
-        get_attr: [dns_host, resource.node_hosts]
-      server:
-        get_attr: [dns_host, resource.host]
-      input_values:
-        node_etc_hosts:
-          list_join:
-          - "\n"
-          - {get_attr: [openshift_nodes, outputs_list, etc_hosts]}
-
-
-  deployment_run_ansible:
-    depends_on: deployment_node_hosts
-    type: OS::Heat::SoftwareDeployment
-    properties:
-      config:
-        get_attr: [openshift_master, resource.run_ansible]
-      server:
-        get_attr: [openshift_master, resource.host]
-      input_values:
-        node_hostnames:
-          list_join:
-          - " "
-          - {get_attr: [openshift_nodes, outputs_list, hostname]}
-
 outputs:
   # TODO: return the master's certificate authority here so we can use the CLI
   # outside of the host.
@@ -347,9 +386,15 @@ outputs:
   host_ips:
     description: IP addresses of the OpenShift nodes
     value: {get_attr: [openshift_nodes, outputs_list, ip_address]}
-  # scale_up_url:
-  #   description: A URL that triggers a scale up event on HTTP POST
-  #   value: {get_attr: [scale_up, alarm_url]}
-  # scale_down_url:
-  #   description: A URL that triggers a scale down event on HTTP POST
-  #   value: {get_attr: [scale_down, alarm_url]}
+  scale_up_url:
+    description: >
+      This URL is the webhook to scale up the autoscaling group.  You
+      can invoke the scale-up operation by doing an HTTP POST to this
+      URL; no body nor extra headers are needed.
+    value: {get_attr: [scale_up_policy, alarm_url]}
+  scale_dn_url:
+    description: >
+      This URL is the webhook to scale down the autoscaling group.
+      You can invoke the scale-down operation by doing an HTTP POST to
+      this URL; no body nor extra headers are needed.
+    value: {get_attr: [scale_down_policy, alarm_url]}


### PR DESCRIPTION
Basic CPU limits are used for scale up/down - we may tune
this based on further tests. SW deployments
which trigger ansible and DNS hostname setting are
now inside the autoscaling group - the reason is that
autoscaling UPDATE events are not propagated to upper
stacks.

A negative side effect of moving SW deployments into
autoscaling group is that these are now called per each node
being added/removed - to minimize number of re-runs of
ansible script it now checks if some changes have been really done
in the inventory file.

Autoscaling is desibled by default and can be enabled by
setting autoscaling=true param.
