### PR TITLE
Stop crond during yum update

### DIFF
--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -5,6 +5,11 @@ set -eu
 set -x
 set -o pipefail
 
+# master and nodes
+# crond was stopped in cloud-init before yum update, make sure it's running
+systemctl status crond && systemctl restart crond
+
+
 echo $NODE_HOSTNAME >> /var/lib/openshift_nodes
 
 export HOME=/root

--- a/fragments/master-boot.sh
+++ b/fragments/master-boot.sh
@@ -24,6 +24,10 @@ export HOME=/root
 cd $HOME
 
 # master and nodes
+# TODO: if crond is updated by "yum update" then crond service start
+# hangs when ran inside cloud-init, temporary workaround is to stop
+# crond service so yum update doesn't try to start it
+systemctl status crond && systemctl stop crond
 retry yum install -y deltarpm || notify_failure "could not install deltarpm"
 retry yum -y update || notify_failure "could not update RPMs"
 


### PR DESCRIPTION
Crond service start hangs for some reason when ran inside
cloud-init. As a workaround stop this service before yum-update
and start it again when running ansible.
