### PR TITLE
Use 3.1 openshift enterprise instead of 3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,8 @@ Deployment
 
 You can pass all environment variables to heat on command line.  However, two example environment files have been given.  
 
-* ``env_origin.yaml`` is an example of the variables to deploy an OpenShift Origin 3 environment.  
-* ``env_aop.yaml`` is an example of the variables to deploy an Atomic Enterprise or OpenShift Enterprise 3 environment.  Note deployment type should be *enterprise* for OpenShift or *atomic-enterprise* for Atomic Enterprise.  Also, a valid RHN subscription is required for deployment. 
+* ``env_origin.yaml`` is an example of the variables to deploy an OpenShift Origin 3 environment.
+* ``env_aop.yaml`` is an example of the variables to deploy an Atomic Enterprise or OpenShift Enterprise 3 environment.  Note deployment type should be *openshift-enterprise* for OpenShift or *atomic-enterprise* for Atomic Enterprise.  Also, a valid RHN subscription is required for deployment.
 
 Assuming your external network is called ``ext_net``, your SSH key is ``default`` and your CentOS 7.1 image is ``centos71`` and your domain name is ``example.com``, this is how you deploy OpenShift Origin:
 

--- a/env_aop.yaml
+++ b/env_aop.yaml
@@ -8,7 +8,7 @@ parameters:
   rhn_username: "Your RHN Username"
   rhn_password: "Your RHN Password"
   rhn_pool: ''
-  deployment_type: enterprise
+  deployment_type: openshift-enterprise
   domain_name: "example.com"
   dns_hostname: "ns"
   master_hostname: "openshift-master"

--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -31,7 +31,7 @@ ansible_ssh_user=$SSH_USER
 # user must be configured for passwordless sudo
 ansible_sudo=true
 
-# deployment type valid values are origin, online and enterprise
+# deployment type valid values are origin, online and openshift-enterprise
 deployment_type=$DEPLOYMENT_TYPE
 
 # htpasswd_auth

--- a/fragments/rhn-register.sh
+++ b/fragments/rhn-register.sh
@@ -20,6 +20,6 @@ if [ -n "$RHN_USERNAME" -a -n "$RHN_PASSWORD" ]; then
                          --enable="rhel-7-server-rpms" \
                          --enable="rhel-7-server-extras-rpms" \
                          --enable="rhel-7-server-optional-rpms" \
-                         --enable="rhel-7-server-ose-3.0-rpms"
+                         --enable="rhel-7-server-ose-3.1-rpms"
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 fi

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -92,7 +92,8 @@ parameters:
   deployment_type:
     type: string
     description: >
-      The type of Openshift deployment.  origin and enterprise are valid 
+      The type of Openshift deployment.  origin and openshift-enterprise
+      are valid.
     default: "origin"
 
   ssh_user:


### PR DESCRIPTION
3.1 is also required for upcoming native HA support.
