### PR TITLE
Don't run os-collect-config from inside cloud-init

### DIFF
--- a/collect-config-setup/fragments/configure_config_agent.sh
+++ b/collect-config-setup/fragments/configure_config_agent.sh
@@ -107,6 +107,3 @@ chmod 755 /usr/bin/heat-config-notify
 # run once to write out /etc/os-collect-config.conf
 os-collect-config --one-time --debug
 cat /etc/os-collect-config.conf
-
-# run again to poll for deployments and run hooks
-os-collect-config --one-time --debug


### PR DESCRIPTION
Let os-collect-config service to pull metadata itself
instead of explicitly trigger first run from cloud-init - this
makes cloud-init run significantly longer.
