### PR TITLE
HA master nodes + LDAP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,28 @@ three nodes. You can get the URLs from Heat by running
 ``heat output-show my_openshift lb_console_url`` and
 ``heat output-show my_openshift lb_api_url``.
 
+LDAP authentication
+===================
+
+You can use an external LDAP server to authenticate OpenShift users. Update
+parameters in ``env_ldap.yaml`` file and include this environment file on stack
+create:
+
+::
+
+    heat stack-create my_openshift -e env.yaml -e openshift-on-openstack/env_ha.yaml -e openshift-on-openstack/env_ldap.yaml -f openshift-on-openstack/openshift.yaml
+
+Example of using an Active Directory server:
+
+::
+
+   parameter_defaults:
+       ldap_hostname: <ldap hostname>
+       ldap_ip: <ip of ldap server>
+       ldap_url: ldap://<ldap hostname>:389/CN=Users,DC=example,DC=openshift,DC=com?sAMAccountName
+       ldap_bind_dn: CN=Administrator,CN=Users,DC=example,DC=openshift,DC=com?sAMAccountName
+       ldap_bind_password: <admin password>
+
 Post-Deployment Setup
 =====================
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ CentOS and RHEL are the only tested distros for now.
 Deployment
 ==========
 
-You can pass all environment variables to heat on command line.  However, two example environment files have been given.  
+You can pass all environment variables to heat on command line.  However, two example environment files have been given.
 
 * ``env_origin.yaml`` is an example of the variables to deploy an OpenShift Origin 3 environment.
 * ``env_aop.yaml`` is an example of the variables to deploy an Atomic Enterprise or OpenShift Enterprise 3 environment.  Note deployment type should be *openshift-enterprise* for OpenShift or *atomic-enterprise* for Atomic Enterprise.  Also, a valid RHN subscription is required for deployment.
@@ -41,7 +41,7 @@ You can pass all environment variables to heat on command line.  However, two ex
 Assuming your external network is called ``ext_net``, your SSH key is ``default`` and your CentOS 7.1 image is ``centos71`` and your domain name is ``example.com``, this is how you deploy OpenShift Origin:
 
 ::
-   
+
   cat << EOF > env.yaml
   parameters:
     ssh_key_name: default
@@ -56,7 +56,7 @@ Assuming your external network is called ``ext_net``, your SSH key is ``default`
     deployment_type: origin
     domain_name: "example.com"
     dns_hostname: "ns"
-    master_hostname: "origin-master"
+    master_hostname_prefix: "origin-master"
     node_hostname_prefix: "origin-node"
     ssh_user: cloud-user
     master_docker_volume_size_gb: 25
@@ -65,7 +65,7 @@ Assuming your external network is called ``ext_net``, your SSH key is ``default`
   EOF
 
    git clone https://github.com/redhat-openstack/openshift-on-openstack.git
-   heat stack-create my_openshift -e env.yaml -f openshift-on-openstack/openshift.yaml 
+   heat stack-create my_openshift -e env.yaml -e openshift-on-openstack/env_single.yaml -f openshift-on-openstack/openshift.yaml
 
 The ``node_count`` parameter specifies how many non-master OpenShift nodes you
 want to deploy. In the example above, we will deploy one master and two nodes.
@@ -80,6 +80,22 @@ installed.`` in the OpenShift master node data in the stack output:
 
    heat output-show my_openshift master_data
 
+Multiple Master Nodes
+=====================
+
+You can deploy OpenShift with multiple master nodes using the 'native' HA
+method (see https://docs.openshift.org/latest/install_config/install/advanced_install.html#multiple-masters
+for details):
+
+::
+
+   heat stack-create my_openshift -e env.yaml -e openshift-on-openstack/env_ha.yaml -f openshift-on-openstack/openshift.yaml
+
+Three master nodes and a loadbalancer will be deployed. Console and API URLs
+then point to the loadbalancer server which distributes requests across all
+three nodes. You can get the URLs from Heat by running
+``heat output-show my_openshift lb_console_url`` and
+``heat output-show my_openshift lb_api_url``.
 
 Post-Deployment Setup
 =====================
@@ -118,7 +134,7 @@ my_openshift master_ip``.
    iptables -I OS_FIREWALL_ALLOW -p tcp -m tcp --dport 1936 -j ACCEPT
    service iptables save; service iptables restart
 
-   # Validate the router is running 
+   # Validate the router is running
    oc get pods
    oc describe pod <router name>
 
@@ -129,13 +145,13 @@ my_openshift master_ip``.
       --selector="region=infra"
 
    # Validate the registry is running
-   oc get pods 
+   oc get pods
 
 Accessing the Web UI
 ====================
 
 You can get the URL for the OpenShift Console (the web UI) from Heat by running
-``heat output-show my_openshift console_url``.
+``heat output-show my_openshift master_console_url``.
 
 Currently, the UI and the resolution for the public hostnames that will be associated
 to services running in OpenShift is dependent on the DNS created internally by

--- a/dns.yaml
+++ b/dns.yaml
@@ -25,12 +25,22 @@ parameters:
   hostname:
     type: string
 
-  master_ip_address:
+  lb_hostname:
     type: string
+    default: ''
 
-  master_hostname:
+  lb_ip:
     type: string
-  
+    default: ''
+
+  ldap_hostname:
+    type: string
+    default: ''
+
+  ldap_ip:
+    type: string
+    default: ''
+
   node_etc_hosts:
     type: string
     default: ''
@@ -88,6 +98,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: add_extra_etc_hosts}
       - config: {get_resource: rhn_register}
       - config: {get_attr: [dns_config_agent, config]}
         type: multipart
@@ -117,15 +128,12 @@ resources:
                 $NODE_IP: {get_param: floating_ip}
                 $NODE_HOSTNAME: {get_param: hostname}
                 $NODE_DOMAIN: {get_param: domain_name}
-                $MASTER_IP: {get_param: master_ip_address}
-                $MASTER_HOSTNAME: {get_param: master_hostname}
               template:
                 {get_file: fragments/etc-hosts}
         - path: /root/dnsmasq.conf
           content:
             str_replace:
               params:
-                $MASTER_IP: {get_param: master_ip_address}
                 $DOMAINNAME: {get_param: domain_name}
               template: {get_file: fragments/dnsmasq.conf}
         - path: /usr/bin/retry
@@ -142,6 +150,17 @@ resources:
             $RHN_PASSWORD: {get_param: rhn_password}
             $POOL_ID: {get_param: rhn_pool}
           template: {get_file: fragments/rhn-register.sh}
+
+  add_extra_etc_hosts:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $LB_DOMAIN: {get_param: domain_name}
+            $LB_HOSTNAME: {get_param: lb_hostname}
+            $LB_IP: {get_param: lb_ip}
+          template: {get_file: fragments/etc-hosts-extra}
 
   node_add:
     type: OS::Heat::SoftwareConfig

--- a/dns.yaml
+++ b/dns.yaml
@@ -160,6 +160,8 @@ resources:
             $LB_DOMAIN: {get_param: domain_name}
             $LB_HOSTNAME: {get_param: lb_hostname}
             $LB_IP: {get_param: lb_ip}
+            $LDAP_HOSTNAME: {get_param: ldap_hostname}
+            $LDAP_IP: {get_param: ldap_ip}
           template: {get_file: fragments/etc-hosts-extra}
 
   node_add:

--- a/env_aop.yaml
+++ b/env_aop.yaml
@@ -11,7 +11,7 @@ parameters:
   deployment_type: openshift-enterprise
   domain_name: "example.com"
   dns_hostname: "ns"
-  master_hostname: "openshift-master"
+  master_hostname_prefix: "openshift-master"
   node_hostname_prefix: "openshift-node"
   ssh_user: cloud-user
   master_docker_volume_size_gb: 25

--- a/env_ha.yaml
+++ b/env_ha.yaml
@@ -1,0 +1,6 @@
+parameters:
+    master_count: 3
+    lb_hostname: 'lb'
+
+resource_registry:
+    OS::LoadBalancer: loadbalancer.yaml

--- a/env_ldap.yaml
+++ b/env_ldap.yaml
@@ -1,0 +1,5 @@
+parameter_defaults:
+    ldap_hostname: ldap.example.com
+    ldap_ip: 192.168.0.1
+    ldap_url: ldap://ldap.example.com:389/cn=users,cn=compat,dc=example,dc=com?uid
+    ldap_insecure: true

--- a/env_origin.yaml
+++ b/env_origin.yaml
@@ -11,7 +11,7 @@ parameters:
   deployment_type: origin
   domain_name: "example.com"
   dns_hostname: "ns"
-  master_hostname: "origin-master"
+  master_hostname_prefix: "origin-master"
   node_hostname_prefix: "origin-node"
   ssh_user: cloud-user
   master_docker_volume_size_gb: 25

--- a/env_single.yaml
+++ b/env_single.yaml
@@ -1,0 +1,5 @@
+# map loadbalancer resource type to a mock definition of loadbalancer which
+# actually doesn't create any resources. This can be replaced in Libery
+# by using OS::Heat::None resource type
+resource_registry:
+    OS::LoadBalancer: loadbalancer_noop.yaml

--- a/fragments/dnsmasq.conf
+++ b/fragments/dnsmasq.conf
@@ -3,5 +3,4 @@ domain-needed
 local=/$DOMAINNAME/
 bind-dynamic
 resolv-file=/etc/resolv.conf
-address=/.cloudapps.$DOMAINNAME/$MASTER_IP
 log-queries

--- a/fragments/etc-hosts
+++ b/fragments/etc-hosts
@@ -2,4 +2,3 @@
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
 $NODE_IP $NODE_HOSTNAME.$NODE_DOMAIN $NODE_HOSTNAME
-$MASTER_IP $MASTER_HOSTNAME.$NODE_DOMAIN $MASTER_HOSTNAME

--- a/fragments/etc-hosts-extra
+++ b/fragments/etc-hosts-extra
@@ -4,6 +4,10 @@ set -eu
 set -x
 set -o pipefail
 
+if [ -n "$LDAP_HOSTNAME" -a -n "$LDAP_IP" ]; then
+    echo "$LDAP_IP $LDAP_HOSTNAME" >> /etc/hosts
+fi
+
 if [ -n "$LB_HOSTNAME" -a -n "$LB_IP" ]; then
     echo "$LB_IP $LB_HOSTNAME $LB_HOSTNAME.$LB_DOMAIN" >> /etc/hosts
 fi

--- a/fragments/etc-hosts-extra
+++ b/fragments/etc-hosts-extra
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eu
+set -x
+set -o pipefail
+
+if [ -n "$LB_HOSTNAME" -a -n "$LB_IP" ]; then
+    echo "$LB_IP $LB_HOSTNAME $LB_HOSTNAME.$LB_DOMAIN" >> /etc/hosts
+fi

--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -39,7 +39,26 @@ openshift_master_cluster_public_hostname: $LB_HOSTNAME.$DOMAINNAME
 EOF
 fi
 
-cat << EOF >> /var/lib/ansible/group_vars/OSv3.yml
+if [ -n "$LDAP_URL" ]; then
+    cat << EOF >> /var/lib/ansible/group_vars/OSv3.yml
+openshift_master_identity_providers:
+  - name: ldap_auth
+    kind: LDAPPasswordIdentityProvider
+    challenge: true
+    login: true
+    bindDN: $LDAP_BIND_DN
+    bindPassword: $LDAP_BIND_PASSWORD
+    ca: '$LDAP_CA'
+    insecure: $LDAP_INSECURE
+    url: $LDAP_URL
+    attributes:
+      id: ['dn']
+      email: ['mail']
+      name: ['cn']
+      preferredUsername: ['$LDAP_PREFERRED_USERNAME']
+EOF
+else
+    cat << EOF >> /var/lib/ansible/group_vars/OSv3.yml
 openshift_master_identity_providers:
   - name: htpasswd_auth
     login: true
@@ -47,6 +66,8 @@ openshift_master_identity_providers:
     kind: HTPasswdPasswordIdentityProvider
     filename: /etc/openshift/openshift-passwd
 EOF
+fi
+
 
 cat << EOF > /var/lib/ansible/inventory
 # Create an OSEv3 group that contains the masters and nodes groups

--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -12,6 +12,12 @@ systemctl status crond && systemctl restart crond
 
 echo $NODE_HOSTNAME >> /var/lib/openshift_nodes
 
+if [ -n "$LB_HOSTNAME" ]; then
+    LB_CHILDREN=lb
+else
+    LB_CHILDREN=''
+fi
+
 export HOME=/root
 
 # Set variables common for all OSEv3 hosts
@@ -21,6 +27,19 @@ ansible_ssh_user: $SSH_USER
 ansible_sudo: true
 deployment_type: $DEPLOYMENT_TYPE # deployment type valid values are origin, online and openshif-enterprise
 osm_default_subdomain: cloudapps.$DOMAINNAME # default subdomain to use for exposed routes
+EOF
+
+if [ -n "$LB_HOSTNAME" ]; then
+    cat << EOF >> /var/lib/ansible/group_vars/OSv3.yml
+openshift_master_cluster_password: openshift_cluster
+openshift_master_cluster_method: native
+openshift_master_cluster_hostname: $LB_HOSTNAME.$DOMAINNAME
+openshift_master_cluster_public_hostname: $LB_HOSTNAME.$DOMAINNAME
+
+EOF
+fi
+
+cat << EOF >> /var/lib/ansible/group_vars/OSv3.yml
 openshift_master_identity_providers:
   - name: htpasswd_auth
     login: true
@@ -35,21 +54,45 @@ cat << EOF > /var/lib/ansible/inventory
 masters
 nodes
 etcd
+$LB_CHILDREN
 
 ### Note - openshift_hostname and openshift_public_hostname are overrides used because OpenStack instance metadata appends .novalocal by default to hostnames
 
-# host group for masters
-[masters]
-#$MASTER_HOSTNAME
-$MASTER_HOSTNAME.$DOMAINNAME openshift_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshift_public_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshift_master_public_console_url=https://$MASTER_HOSTNAME.$DOMAINNAME:8443/console openshift_master_public_api_url=https://$MASTER_HOSTNAME.$DOMAINNAME:8443
+EOF
 
-[etcd]
-$MASTER_HOSTNAME.$DOMAINNAME openshift_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshift_public_hostname=$MASTER_HOSTNAME.$DOMAINNAME
+if [ -n "$LB_HOSTNAME" ]; then
+    cat << EOF >> /var/lib/ansible/inventory
+[lb]
+$LB_HOSTNAME.$DOMAINNAME
+EOF
+fi
+
+echo -e "\n[masters]" >> /var/lib/ansible/inventory
+for node in $ALL_MASTER_NODES;do
+    if [ -n "$LB_HOSTNAME" ]; then
+        public_name="$LB_HOSTNAME.$DOMAINNAME"
+    else
+        public_name="$node.$DOMAINNAME"
+    fi
+    echo "$node.$DOMAINNAME openshift_hostname=$node.$DOMAINNAME openshift_public_hostname=$public_name openshift_master_public_console_url=https://$public_name:8443/console openshift_master_public_api_url=https://$public_name:8443" >> /var/lib/ansible/inventory
+done
+
+
+echo -e "\n[etcd]" >> /var/lib/ansible/inventory
+for node in $ALL_MASTER_NODES;do
+    if [ -n "$LB_HOSTNAME" ]; then
+        public_name="$LB_HOSTNAME.$DOMAINNAME"
+    else
+        public_name="$node.$DOMAINNAME"
+    fi
+    echo "$node.$DOMAINNAME openshift_hostname=$node.$DOMAINNAME openshift_public_hostname=$public_name" >> /var/lib/ansible/inventory
+done
 
 # host group for nodes
-[nodes]
-$MASTER_HOSTNAME.$DOMAINNAME openshift_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshift_public_hostname=$MASTER_HOSTNAME.$DOMAINNAME openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
-EOF
+echo -e "\n[nodes]" >> /var/lib/ansible/inventory
+for node in $ALL_MASTER_NODES;do
+    echo "$node.$DOMAINNAME openshift_hostname=$node.$DOMAINNAME openshift_public_hostname=$node.$DOMAINNAME openshift_node_labels=\"{'region': 'infra', 'zone': 'default'}\"" >> /var/lib/ansible/inventory
+done
 
 # this script is triggered for each node being added, let's
 # give all nodes some time to write their hostnames into the list (this
@@ -83,7 +126,7 @@ fi
 
 # NOTE: Ignore the known_hosts check/propmt for now:
 export ANSIBLE_HOST_KEY_CHECKING=False
-ansible-playbook --inventory /var/lib/ansible/inventory $HOME/openshift-ansible/playbooks/byo/config.yml
+ansible-playbook --inventory /var/lib/ansible/inventory $HOME/openshift-ansible/playbooks/byo/config.yml > /var/log/ansible.$$ 2>&1
 
 # Move docker-storage-setup unit file back in place
 mv $HOME/docker-storage-setup.service /usr/lib/systemd/system

--- a/loadbalancer.yaml
+++ b/loadbalancer.yaml
@@ -1,0 +1,172 @@
+heat_template_version: 2014-10-16
+
+
+description: >
+  A host providing the loadbalancing for the OpenShift master nodes.
+
+
+parameters:
+
+  key_name:
+    type: string
+    constraints:
+    - custom_constraint: nova.keypair
+
+  image:
+    type: string
+    constraints:
+    - custom_constraint: glance.image
+
+  flavor:
+    type: string
+    constraints:
+    - custom_constraint: nova.flavor
+
+  hostname:
+    type: string
+
+  domain_name:
+    type: string
+
+  rhn_username:
+    type: string
+
+  rhn_password:
+    type: string
+    hidden: true
+
+  rhn_pool:
+    type: string
+    hidden: true
+
+  ssh_user:
+    type: string
+
+  external_network:
+    type: string
+    constraints:
+    - custom_constraint: neutron.network
+
+  fixed_network:
+    type: string
+    constraints:
+    - custom_constraint: neutron.network
+
+  fixed_subnet:
+    type: string
+    constraints:
+    - custom_constraint: neutron.subnet
+
+  ansible_public_key:
+    type: string
+
+resources:
+
+  floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {get_param: external_network}
+      port_id: {get_resource: port}
+
+  port:
+    type: OS::Neutron::Port
+    properties:
+      security_groups:
+      - {get_resource: security_group}
+      network: {get_param: fixed_network}
+      fixed_ips:
+      - subnet: {get_param: fixed_subnet}
+      replacement_policy: AUTO
+
+  security_group:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+      - protocol: icmp
+      # Just open everything for now:
+      - protocol: tcp
+        port_range_min: 0
+        port_range_max: 65535
+      - protocol: udp
+        port_range_min: 0
+        port_range_max: 65535
+
+  host:
+    type: OS::Nova::Server
+    properties:
+      name:
+        str_replace:
+          template: "HOST.DOMAIN"
+          params:
+            HOST: {get_param: hostname}
+            DOMAIN: {get_param: domain_name}
+      admin_user: {get_param: ssh_user}
+      image: {get_param: image}
+      flavor: {get_param: flavor}
+      key_name: {get_param: key_name}
+      networks:
+      - port: {get_resource: port}
+      user_data_format: SOFTWARE_CONFIG
+      user_data: {get_resource: init}
+
+  init:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+      - config: {get_resource: set_hostname}
+      - config: {get_resource: included_files}
+      - config: {get_resource: rhn_register}
+
+  set_hostname:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        hostname: {get_param: hostname}
+        fqdn:
+          str_replace:
+            template: "HOST.DOMAIN"
+            params:
+              HOST: {get_param: hostname}
+              DOMAIN: {get_param: domain_name}
+
+  included_files:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        write_files:
+        - path: /usr/bin/retry
+          permissions: 0755
+          content: {get_file: fragments/retry.sh}
+        ssh_authorized_keys:
+        - {get_param: ansible_public_key}
+
+  rhn_register:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $RHN_USERNAME: {get_param: rhn_username}
+            $RHN_PASSWORD: {get_param: rhn_password}
+            $POOL_ID: {get_param: rhn_pool}
+          template: {get_file: fragments/rhn-register.sh}
+
+outputs:
+  floating_ip:
+    value: {get_attr: [floating_ip, floating_ip_address]}
+
+  console_url:
+    value:
+      str_replace:
+        params:
+          HOSTNAME: {get_param: hostname}
+          DOMAINNAME: {get_param: domain_name}
+        template: "https://HOSTNAME.DOMAINNAME:8443/console/"
+
+  api_url:
+    value:
+      str_replace:
+        params:
+          HOSTNAME: {get_param: hostname}
+          DOMAINNAME: {get_param: domain_name}
+        template: "https://HOSTNAME.DOMAINNAME:8443/"

--- a/loadbalancer_noop.yaml
+++ b/loadbalancer_noop.yaml
@@ -1,0 +1,61 @@
+heat_template_version: 2014-10-16
+
+
+description: >
+  A template which provides a fake loadbalancer definition used in situation when HA is not required.
+
+
+parameters:
+
+  key_name:
+    type: string
+    constraints:
+    - custom_constraint: nova.keypair
+
+  image:
+    type: string
+    constraints:
+    - custom_constraint: glance.image
+
+  flavor:
+    type: string
+    constraints:
+    - custom_constraint: nova.flavor
+
+  hostname:
+    type: string
+
+  domain_name:
+    type: string
+
+  rhn_username:
+    type: string
+
+  rhn_password:
+    type: string
+    hidden: true
+
+  rhn_pool:
+    type: string
+    hidden: true
+
+  ssh_user:
+    type: string
+
+  external_network:
+    type: string
+    constraints:
+    - custom_constraint: neutron.network
+
+  fixed_network:
+    type: string
+    constraints:
+    - custom_constraint: neutron.network
+
+  fixed_subnet:
+    type: string
+    constraints:
+    - custom_constraint: neutron.subnet
+
+  ansible_public_key:
+    type: string

--- a/master.yaml
+++ b/master.yaml
@@ -47,19 +47,10 @@ parameters:
   deployment_type:
     type: string
 
-  port:
-    description: >
-      Neutron port (with a floating IP address) to assign to the OpenShift
-      Master Nova Server
-    type: string
-
-  hostname:
+  hostname_prefix:
     type: string
 
   domain_name:
-    type: string
-
-  floating_ip:
     type: string
 
   ansible_public_key:
@@ -86,7 +77,63 @@ parameters:
     type: number
     default: 4000
 
+  external_network:
+    type: string
+    constraints:
+    - custom_constraint: neutron.network
+
+  dns_node:
+    type: string
+    default: ''
+
+  dns_node_add:
+    type: string
+    default: ''
+
+  fixed_network:
+    type: string
+    constraints:
+    - custom_constraint: neutron.network
+
+  fixed_subnet:
+    type: string
+    constraints:
+    - custom_constraint: neutron.subnet
+
+  lb_hostname:
+    type: string
+    default: ''
+
 resources:
+
+  port:
+    type: OS::Neutron::Port
+    properties:
+      security_groups:
+      - {get_resource: master_security_group}
+      network: {get_param: fixed_network}
+      fixed_ips:
+      - subnet: {get_param: fixed_subnet}
+      replacement_policy: AUTO
+
+  master_security_group:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+      - protocol: icmp
+      # Just open everything for now:
+      - protocol: tcp
+        port_range_min: 0
+        port_range_max: 65535
+      - protocol: udp
+        port_range_min: 0
+        port_range_max: 65535
+
+  random_hostname_suffix:
+    type: OS::Heat::RandomString
+    properties:
+      character_classes: [{"class": lowercase}, {"class": digits}]
+      length: 8
 
   config_agent:
     type: collect-config-setup/install_config_agent_centos_yum.yaml
@@ -96,16 +143,17 @@ resources:
     properties:
       name:
         str_replace:
-          template: "HOST.DOMAIN"
+          template: "HOST-SUFFIX.DOMAIN"
           params:
-            HOST: {get_param: hostname}
+            HOST: {get_param: hostname_prefix}
+            SUFFIX: {get_attr: [random_hostname_suffix, value]}
             DOMAIN: {get_param: domain_name}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
       flavor: {get_param: flavor}
       key_name: {get_param: key_name}
       networks:
-      - port: {get_param: port}
+      - port: {get_resource: port}
       user_data_format: SOFTWARE_CONFIG
       user_data: {get_resource: init}
 
@@ -119,6 +167,12 @@ resources:
     properties:
       instance_uuid: {get_resource: host}
       volume_id: {get_resource: docker_volume}
+
+  floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {get_param: external_network}
+      port_id: {get_resource: port}
 
   init:
     type: OS::Heat::MultipartMime
@@ -135,12 +189,18 @@ resources:
     type: OS::Heat::CloudConfig
     properties:
       cloud_config:
-        hostname: {get_param: hostname}
+        hostname:
+          str_replace:
+            template: "HOST-SUFFIX"
+            params:
+              HOST: {get_param: hostname_prefix}
+              SUFFIX: {get_attr: [random_hostname_suffix, value]}
         fqdn:
           str_replace:
-            template: "HOST.DOMAIN"
+            template: "HOST-SUFFIX.DOMAIN"
             params:
-              HOST: {get_param: hostname}
+              HOST: {get_param: hostname_prefix}
+              SUFFIX: {get_attr: [random_hostname_suffix, value]}
               DOMAIN: {get_param: domain_name}
 
   included_files:
@@ -152,8 +212,13 @@ resources:
           content:
             str_replace:
               params:
-                $NODE_IP: {get_param: floating_ip}
-                $NODE_HOSTNAME: {get_param: hostname}
+                $NODE_IP: {get_attr: [floating_ip, floating_ip_address]}
+                $NODE_HOSTNAME:
+                  str_replace:
+                    template: "HOST-SUFFIX"
+                    params:
+                      HOST: {get_param: hostname_prefix}
+                      SUFFIX: {get_attr: [random_hostname_suffix, value]}
                 $NODE_DOMAIN: {get_param: domain_name}
               template: {get_file: fragments/etc-node-hosts}
         - path: /root/.ssh/id_rsa
@@ -187,7 +252,7 @@ resources:
         str_replace:
           params:
             $DNS_IP: {get_param: dns_ip}
-            $MASTER_IP: {get_param: floating_ip}
+            $MASTER_IP: {get_attr: [floating_ip, floating_ip_address]}
             $OPENSHIFT_ANSIBLE_GIT_URL: {get_param: openshift_ansible_git_url}
             $OPENSHIFT_ANSIBLE_GIT_REV: {get_param: openshift_ansible_git_rev}
             $WC_NOTIFY: { get_attr: ['wait_handle', 'curl_cli'] }
@@ -199,15 +264,34 @@ resources:
       group: script
       inputs:
         - name: node_hostname
+        - name: all_master_nodes
       config:
         str_replace:
           params:
-            $MASTER_HOSTNAME: {get_param: hostname}
+            $ALL_MASTER_NODES: $all_master_nodes
             $DOMAINNAME: {get_param: domain_name}
             $NODE_HOSTNAME: $node_hostname
             $SSH_USER: {get_param: ssh_user}
             $DEPLOYMENT_TYPE: {get_param: deployment_type}
+            $LB_HOSTNAME: {get_param: lb_hostname}
           template: {get_file: fragments/master-ansible.sh}
+
+  deployment_dns_node_add:
+    type: OS::Heat::SoftwareDeployment
+    properties:
+      config:
+        get_param: dns_node_add
+      server:
+        get_param: dns_node
+      input_values:
+        node_etc_host:
+          str_replace:
+              template: "IP HOST-SUFFIX.DOMAIN HOST-SUFFIX #openshift"
+              params:
+                IP: {get_attr: [floating_ip, floating_ip_address]}
+                HOST: {get_param: hostname_prefix}
+                SUFFIX: {get_attr: [random_hostname_suffix, value]}
+                DOMAIN: {get_param: domain_name}
 
   wait_condition:
     type: OS::Heat::WaitCondition
@@ -223,15 +307,28 @@ outputs:
     value:
       str_replace:
         params:
-          HOSTNAME: {get_param: hostname}
+          HOSTNAME: {get_param: hostname_prefix}
+          SUFFIX: {get_attr: [random_hostname_suffix, value]}
           DOMAINNAME: {get_param: domain_name}
-        template: "https://HOSTNAME.DOMAINNAME:8443/console/"
+        template: "https://HOSTNAME-SUFFIX.DOMAINNAME:8443/console/"
   api_url:
     value:
       str_replace:
         params:
-          HOSTNAME: {get_param: hostname}
+          HOSTNAME: {get_param: hostname_prefix}
+          SUFFIX: {get_attr: [random_hostname_suffix, value]}
           DOMAINNAME: {get_param: domain_name}
-        template: "https://HOSTNAME.DOMAINNAME:8443/"
+        template: "https://HOSTNAME-SUFFIX.DOMAINNAME:8443/"
   wc_data:
     value: { get_attr: ['wait_condition', 'data'] }
+  hostname:
+    value:
+      str_replace:
+        template: "HOST-SUFFIX"
+        params:
+          HOST: {get_param: hostname_prefix}
+          SUFFIX: {get_attr: [random_hostname_suffix, value]}
+  host:
+    value: {get_resource: host}
+  run_ansible:
+    value: {get_resource: run_ansible}

--- a/master.yaml
+++ b/master.yaml
@@ -104,6 +104,30 @@ parameters:
     type: string
     default: ''
 
+  ldap_url:
+    type: string
+    default: ''
+
+  ldap_preferred_username:
+    type: string
+    default: 'uid'
+
+  ldap_bind_dn:
+    type: string
+    default: ''
+
+  ldap_bind_password:
+    type: string
+    default: ''
+
+  ldap_ca:
+    type: string
+    default: ''
+
+  ldap_insecure:
+    type: string
+    default: false
+
 resources:
 
   port:
@@ -274,6 +298,12 @@ resources:
             $SSH_USER: {get_param: ssh_user}
             $DEPLOYMENT_TYPE: {get_param: deployment_type}
             $LB_HOSTNAME: {get_param: lb_hostname}
+            $LDAP_URL: {get_param: ldap_url}
+            $LDAP_PREFERRED_USERNAME: {get_param: ldap_preferred_username}
+            $LDAP_BIND_DN: {get_param: ldap_bind_dn}
+            $LDAP_BIND_PASSWORD: {get_param: ldap_bind_password}
+            $LDAP_CA: {get_param: ldap_ca}
+            $LDAP_INSECURE: {get_param: ldap_insecure}
           template: {get_file: fragments/master-ansible.sh}
 
   deployment_dns_node_add:

--- a/node.yaml
+++ b/node.yaml
@@ -75,6 +75,10 @@ parameters:
     type: string
     default: ''
 
+  all_master_nodes:
+    type: string
+    default: ''
+
   master_run_ansible:
     type: string
     default: ''
@@ -321,6 +325,7 @@ resources:
               HOST: {get_param: hostname_prefix}
               SUFFIX: {get_attr: [random_hostname_suffix, value]}
               DOMAIN: {get_param: domain_name}
+        all_master_nodes: {get_param: all_master_nodes}
 
   wait_condition:
     type: OS::Heat::WaitCondition

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -38,10 +38,17 @@ parameters:
     description: address of a dns nameserver reachable in your environment
     default: 8.8.8.8
 
+  master_count:
+    type: number
+    description: >
+      Number of non-master nodes to create.
+    default: 1
+
   node_count:
     type: number
     description: >
       Number of non-master nodes to create.
+    default: 1
 
   rhn_username:
     type: string
@@ -77,7 +84,13 @@ parameters:
       The hostname that is going to be set for the DNS server.
     default: "ns"
 
-  master_hostname:
+  lb_hostname:
+    type: string
+    description: >
+      The hostname that is going to be set for the loadbalancer server.
+    default: ''
+
+  master_hostname_prefix:
     type: string
     description: >
       The hostname that is going to be set for the master.
@@ -128,7 +141,8 @@ parameters:
     description: >
       The git revision of the openshift-ansible repository to check out to.
     # Known working version on Centos 7 + Origin:
-    default: "8f6c6824073dff0cea3cd793db2745fb6cf52931"
+    #default: "8f6c6824073dff0cea3cd793db2745fb6cf52931"
+    default: "master"
 
   autoscaling:
     type: boolean
@@ -172,6 +186,24 @@ resources:
       router_id: {get_resource: external_router}
       subnet: {get_resource: fixed_subnet}
 
+  lb_host:
+    depends_on: external_router_interface
+    type: OS::LoadBalancer
+    properties:
+      image: {get_param: server_image}
+      flavor: {get_param: flavor}
+      key_name: {get_param: ssh_key_name}
+      ssh_user: {get_param: ssh_user}
+      rhn_username: {get_param: rhn_username}
+      rhn_password: {get_param: rhn_password}
+      rhn_pool: {get_param: rhn_pool}
+      hostname: {get_param: lb_hostname}
+      domain_name: {get_param: domain_name}
+      external_network: {get_param: external_network}
+      fixed_network: {get_resource: fixed_network}
+      fixed_subnet: {get_resource: fixed_subnet}
+      ansible_public_key: {get_attr: [ansible_keys, public_key]}
+
   dns_host:
     depends_on: external_router_interface
     type: dns.yaml
@@ -184,34 +216,42 @@ resources:
       rhn_password: {get_param: rhn_password}
       rhn_pool: {get_param: rhn_pool}
       hostname: {get_param: dns_hostname}
-      master_ip_address: {get_attr: [master_floating_ip, floating_ip_address]}
-      master_hostname: {get_param: master_hostname}
       port: {get_resource: dnsmasq_port}
       domain_name: {get_param: domain_name}
       floating_ip: {get_attr: [dnsmasq_floating_ip, floating_ip_address]}
+      lb_hostname: {get_param: lb_hostname}
+      lb_ip: {get_attr: [lb_host, floating_ip]}
 
-  openshift_master:
+  openshift_masters:
     depends_on: external_router_interface
-    type: master.yaml
+    type: OS::Heat::ResourceGroup
     properties:
-      image: {get_param: server_image}
-      flavor: {get_param: flavor}
-      key_name: {get_param: ssh_key_name}
-      ssh_user: {get_param: ssh_user}
-      dns_ip: {get_attr: [dnsmasq_floating_ip, floating_ip_address]}
-      port: {get_resource: master_port}
-      rhn_username: {get_param: rhn_username}
-      rhn_password: {get_param: rhn_password}
-      rhn_pool: {get_param: rhn_pool}
-      deployment_type: {get_param: deployment_type}
-      docker_volume_size: {get_param: master_docker_volume_size_gb}
-      floating_ip: {get_attr: [master_floating_ip, floating_ip_address]}
-      hostname: {get_param: master_hostname}
-      domain_name: {get_param: domain_name}
-      ansible_public_key: {get_attr: [ansible_keys, public_key]}
-      ansible_private_key: {get_attr: [ansible_keys, private_key]}
-      openshift_ansible_git_url: {get_param: openshift_ansible_git_url}
-      openshift_ansible_git_rev: {get_param: openshift_ansible_git_rev}
+      count: {get_param: master_count}
+      resource_def:
+        type: master.yaml
+        properties:
+          image: {get_param: server_image}
+          flavor: {get_param: flavor}
+          key_name: {get_param: ssh_key_name}
+          ssh_user: {get_param: ssh_user}
+          dns_ip: {get_attr: [dnsmasq_floating_ip, floating_ip_address]}
+          rhn_username: {get_param: rhn_username}
+          rhn_password: {get_param: rhn_password}
+          rhn_pool: {get_param: rhn_pool}
+          deployment_type: {get_param: deployment_type}
+          docker_volume_size: {get_param: master_docker_volume_size_gb}
+          hostname_prefix: {get_param: master_hostname_prefix}
+          domain_name: {get_param: domain_name}
+          ansible_public_key: {get_attr: [ansible_keys, public_key]}
+          ansible_private_key: {get_attr: [ansible_keys, private_key]}
+          openshift_ansible_git_url: {get_param: openshift_ansible_git_url}
+          openshift_ansible_git_rev: {get_param: openshift_ansible_git_rev}
+          dns_node: {get_attr: [dns_host, resource.host]}
+          dns_node_add: {get_attr: [dns_host, resource.node_add]}
+          fixed_network: {get_resource: fixed_network}
+          fixed_subnet: {get_resource: fixed_subnet}
+          external_network: {get_param: external_network}
+          lb_hostname: {get_param: lb_hostname}
 
   openshift_nodes:
     depends_on: external_router_interface
@@ -238,12 +278,16 @@ resources:
           hostname_prefix: {get_param: node_hostname_prefix}
           domain_name: {get_param: domain_name}
           ansible_public_key: {get_attr: [ansible_keys, public_key]}
-          master_node: {get_attr: [openshift_master, resource.host]}
-          master_run_ansible: {get_attr: [openshift_master, resource.run_ansible]}
+          master_node: {get_attr: [openshift_masters, resource.0.host]}
+          master_run_ansible: {get_attr: [openshift_masters, resource.0.run_ansible]}
           dns_node: {get_attr: [dns_host, resource.host]}
           dns_node_cleanup: {get_attr: [dns_host, resource.node_cleanup]}
           dns_node_add: {get_attr: [dns_host, resource.node_add]}
           metadata: {"metering.stack": {get_param: "OS::stack_id"}}
+          all_master_nodes:
+            list_join:
+              - " "
+              - {get_attr: [openshift_masters, hostname]}
 
   scale_up_policy:
     type: OS::Heat::ScalingPolicy
@@ -320,35 +364,6 @@ resources:
       floating_network: {get_param: external_network}
       port_id: {get_resource: dnsmasq_port}
 
-  master_port:
-    type: OS::Neutron::Port
-    properties:
-      security_groups:
-      - {get_resource: master_security_group}
-      network: {get_resource: fixed_network}
-      fixed_ips:
-      - subnet: {get_resource: fixed_subnet}
-      replacement_policy: AUTO
-
-  master_security_group:
-    type: OS::Neutron::SecurityGroup
-    properties:
-      rules:
-      - protocol: icmp
-      # Just open everything for now:
-      - protocol: tcp
-        port_range_min: 0
-        port_range_max: 65535
-      - protocol: udp
-        port_range_min: 0
-        port_range_max: 65535
-
-  master_floating_ip:
-    type: OS::Neutron::FloatingIP
-    properties:
-      floating_network: {get_param: external_network}
-      port_id: {get_resource: master_port}
-
   ansible_keys:
     type: OS::Nova::KeyPair
     properties:
@@ -363,21 +378,33 @@ outputs:
   # TODO: return the master's certificate authority here so we can use the CLI
   # outside of the host.
   # It's stored at `/etc/openshift/master/ca.crt`
-  master_ip:
-    description: IP address of the OpenShift master node
-    value: {get_attr: [master_floating_ip, floating_ip_address]}
+  #master_ip:
+  #  description: IP address of the OpenShift master node
+  #  value: {get_attr: [master_floating_ip, floating_ip_address]}
   dns_ip:
     description: IP address of the DNS server OpenShift relies on
     value: {get_attr: [dnsmasq_floating_ip, floating_ip_address]}
-  console_url:
+  lb_console_url:
     description: URL of the OpenShift web console
-    value: {get_attr: [openshift_master, console_url]}
-  api_url:
+    value: {get_attr: [lb_host, console_url]}
+  lb_api_url:
     description: URL entrypoint to the OpenShift API
-    value: {get_attr: [openshift_master, api_url]}
-  master_data:
-    description: Status of boot setup on the master.
-    value: {get_attr: [openshift_master, wc_data]}
+    value: {get_attr: [lb_host, api_url]}
+  master_console_url:
+    description: URL of the OpenShift web console
+    value:
+      list_join:
+        - ","
+        - {get_attr: [openshift_masters, console_url]}
+  master_api_url:
+    description: URL entrypoint to the OpenShift API
+    value:
+      list_join:
+        - ","
+        - {get_attr: [openshift_masters, api_url]}
+  #master_data:
+  #  description: Status of boot setup on the master.
+  #  value: {get_attr: [openshift_master, wc_data]}
   host_ips:
     description: IP addresses of the OpenShift nodes
     value: {get_attr: [openshift_nodes, outputs_list, ip_address]}


### PR DESCRIPTION
Multiple master nodes can be deployed now simply by
including '-e env_ha.yaml' when deploying OpenShift stack.
Including this environemnt file will cause that three master nodes
and a loadbalancer will be created.

To make openshift.yaml reusable both for single/multiple deployments
there is now also a mock loadbalancer_noop.yaml file (which actually
does nothing) for usage with single master node.

An alternative to this approach would be keeping two separate templates
for single and multiple master nodes.
