### PR TITLE
Check if os-collect-config is present during cloud-init

### DIFF
--- a/dns.yaml
+++ b/dns.yaml
@@ -69,6 +69,11 @@ parameters:
   ssh_user:
     type: string
 
+  timeout:
+    description: Time to wait until the master setup is ready.
+    type: number
+    default: 4000
+
 resources:
 
   dns_config_agent:
@@ -196,4 +201,18 @@ resources:
   boot_config:
     type: OS::Heat::SoftwareConfig
     properties:
-      config: {get_file: fragments/dnsmasq.sh}
+      config:
+        str_replace:
+          params:
+            $WC_NOTIFY: { get_attr: ['wait_handle', 'curl_cli'] }
+          template: {get_file: fragments/dnsmasq.sh}
+
+
+  wait_condition:
+    type: OS::Heat::WaitCondition
+    properties:
+      handle: {get_resource: wait_handle}
+      timeout: {get_param: timeout}
+
+  wait_handle:
+    type: OS::Heat::WaitConditionHandle

--- a/fragments/dnsmasq.sh
+++ b/fragments/dnsmasq.sh
@@ -3,7 +3,21 @@
 set -eu
 set -o pipefail
 
-retry yum install -y dnsmasq
+function notify_success() {
+    $WC_NOTIFY --data-binary  "{\"status\": \"SUCCESS\", \"reason\": \"$1\", \"data\": \"$1\"}"
+    exit 0
+}
+
+function notify_failure() {
+    $WC_NOTIFY --data-binary "{\"status\": \"FAILURE\", \"reason\": \"$1\", \"data\": \"$1\"}"
+    exit 1
+}
+
+systemctl is-enabled os-collect-config || notify_failure "os-collect-config service is not installed or enabled"
+
+retry yum install -y dnsmasq || notify_failure "can't install dnsmasq"
 \cp /root/dnsmasq.conf /etc/dnsmasq.conf
-systemctl enable dnsmasq
-systemctl restart dnsmasq
+systemctl enable dnsmasq || notify_failure "can't enable dnsmasq"
+systemctl restart dnsmasq || notify_failure "can't start dnsmasq"
+
+notify_success "DNS node is ready."

--- a/fragments/master-boot.sh
+++ b/fragments/master-boot.sh
@@ -14,6 +14,8 @@ function notify_failure() {
     exit 1
 }
 
+systemctl is-enabled os-collect-config || notify_failure "os-collect-config service is not installed or enabled"
+
 # master and nodes
 # Set the DNS to the one provided
 sed -i 's/search openstacklocal/&\nnameserver $DNS_IP/' /etc/resolv.conf


### PR DESCRIPTION
If cloud-init uses multipart MIME, then all scripts run no matter if
previous in chain failed, so it's possible that false-positive success is
reported. If os-collect-config is not started, then none of post-deployment
scripts is executed and stack-create times out. It also may cause that
stack-delete is stuck in DELETE_IN_PROGRESS because heat waits on
executing pre-delete scripts which are done by os-collect-config on
master node. It would be better to check if os-collect-config is running
but the problem is that os-collect-config is started once cloud-init (which
is systemd service too) finishes.
