### PR TITLE
constrain deployments to accepted values

### DIFF
--- a/openshift.yaml
+++ b/openshift.yaml
@@ -114,6 +114,10 @@ parameters:
       The type of Openshift deployment.  origin and openshift-enterprise
       are valid.
     default: "origin"
+    constraints:
+      - allowed_values:
+        - origin
+        - openshift-enterprise
 
   ssh_user:
     type: string


### PR DESCRIPTION
Add a constraint to the deployment types so that incorrect values can be flagged before proceeding.
