### PR TITLE
Disable ansible hostname checking

### DIFF
--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -40,6 +40,7 @@ ansible_ssh_user: $SSH_USER
 ansible_sudo: true
 deployment_type: $DEPLOYMENT_TYPE # deployment type valid values are origin, online and openshif-enterprise
 osm_default_subdomain: cloudapps.$DOMAINNAME # default subdomain to use for exposed routes
+openshift_override_hostname_check: true
 EOF
 
 if [ -n "$LB_HOSTNAME" ]; then


### PR DESCRIPTION
Ansbile playbook checks if hostname's resolved IP is
set for each host, this is problem on OpenStack where IP
actually doesn't exist on hosts but is done by IP routing.
