### PR TITLE
add lbaas option to packstack invocation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,6 +73,7 @@ ln -s /home/images /var/lib/libvirt/images
 #   This produces the keystonrc_admin file used below
 packstack --allinone --provision-all-in-one-ovs-bridge=y \
   --os-heat-install=y --os-heat-cfn-install=y \
+  --os-neutron-lbaas-install=y \
   --keystone-admin-passwd=password --keystone-demo-passwd=password
 
 # Retrieve the Heat templates for OpenShift


### PR DESCRIPTION
lbaas service not enabled by default in packstack Liberty 7.0.0.dev1682.g42b3426
