### PR TITLE
Openstack support

### DIFF
--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -85,6 +85,10 @@ openshift_use_flannel: $openshift_use_flannel
 EOF
 fi
 
+if [ -n "$OS_USERNAME" ] && [ -n "$OS_PASSWORD" ] && [ -n "$OS_AUTH_URL" ] && [ -n "$OS_TENANT_NAME" ]; then
+    echo "openshift_cloud_provider: openstack" >> /var/lib/ansible/group_vars/OSv3.yml
+fi
+
 # Set variables common for all nodes
 cat << EOF > /var/lib/ansible/group_vars/nodes.yml
 openshift_node_labels:

--- a/infra.yaml
+++ b/infra.yaml
@@ -265,7 +265,12 @@ resources:
   host:
     type: OS::Nova::Server
     properties:
-      name: {get_param: hostname}
+      name:
+        str_replace:
+          template: "HOST.DOMAIN"
+          params:
+            HOST: {get_param: hostname}
+            DOMAIN: {get_param: domain_name}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
       flavor: {get_param: flavor}

--- a/master.yaml
+++ b/master.yaml
@@ -213,7 +213,12 @@ resources:
   host:
     type: OS::Nova::Server
     properties:
-      name: {get_param: hostname}
+      name:
+        str_replace:
+          template: "HOST.DOMAIN"
+          params:
+            HOST: {get_param: hostname}
+            DOMAIN: {get_param: domain_name}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
       flavor: {get_param: flavor}

--- a/node.yaml
+++ b/node.yaml
@@ -169,10 +169,11 @@ resources:
     properties:
       name:
         str_replace:
-          template: "HOST-SUFFIX"
+          template: "HOST-SUFFIX.DOMAIN"
           params:
             HOST: {get_param: hostname}
             SUFFIX: {get_attr: [random_hostname_suffix, value]}
+            DOMAIN: {get_param: domain_name}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
       flavor: {get_param: flavor}


### PR DESCRIPTION
The Openstack cloud provider for Openshift needs the virtual machine to have the same name than the hostnames.

The just merged PR on openshift-ansible (https://github.com/openshift/openshift-ansible/pull/883) requires an additional parameter `openshift_cloud_provider` that must be set to `openstack`.
