### PR TITLE
Enable dedicated loadbalancer node (again)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -188,6 +188,37 @@ three nodes. You can get the URLs from Heat by running
 `heat output-show my_openshift console_url` and
 `heat output-show my_openshift api_url`.
 
+== Select Loadbalancer Type
+
+By default Neutron LBaaS is used for setting up loadbalancer. If LBaaS is not
+available in your OpenStack environment you can deploy a dedicated loadbalancer node
+by including `env_loadbalancer_dedicated.yaml` environment file when you create
+the stack:
+
+```bash
+heat stack-create my_openshift \
+   -e openshift_parameters.yaml \
+   -P master_count=3 \
+   -f openshift-on-openstack/openshift.yaml\
+   -e env_loadbalancer_dedicated.yaml
+```
+
+Then an addtional instance will be created and openshift-ansible will install and
+configure loadbalancer service.
+
+Do not use dedicated loadbalancer when deploying only single master node,
+openshift-ansible skips loadbalancer setup if only single master node is used. For
+single master node you can disable loadbalancer node by including
+`env_loadbalancer_none.yaml` environment file when you create the stack:
+
+```bash
+heat stack-create my_openshift \
+   -e openshift_parameters.yaml \
+   -P master_count=1 \
+   -f openshift-on-openstack/openshift.yaml\
+   -e env_loadbalancer_none.yaml
+```
+
 == LDAP authentication
 
 You can use an external LDAP server to authenticate OpenShift users. Update

--- a/env_loadbalancer_dedicated.yaml
+++ b/env_loadbalancer_dedicated.yaml
@@ -1,0 +1,8 @@
+parameters:
+    loadbalancer_type: dedicated
+    # once openshift-ansible supports containerzed loadbalancer node setup
+    # this can be deleted
+    loadbalancer_image: centos72
+
+resource_registry:
+    OOShift::LoadBalancer: loadbalancer_dedicated.yaml

--- a/env_loadbalancer_none.yaml
+++ b/env_loadbalancer_none.yaml
@@ -1,0 +1,5 @@
+parameters:
+    loadbalancer_type: 'none'
+
+resource_registry:
+    OOShift::LoadBalancer: loadbalancer_none.yaml

--- a/env_origin.yaml
+++ b/env_origin.yaml
@@ -17,3 +17,6 @@ parameters:
   node_docker_volume_size_gb: 25
   openshift_ansible_git_url: https://github.com/openshift/openshift-ansible.git
   openshift_ansible_git_rev: master
+
+resource_registry:
+    OOShift::LoadBalancer: loadbalancer_neutron.yaml

--- a/infra.yaml
+++ b/infra.yaml
@@ -216,6 +216,9 @@ parameters:
   skip_dns:
     type: boolean
 
+  loadbalancer_type:
+    type: string
+
   openshift_ansible_git_url:
     description: >
       The location of the OpenShift Ansible playbooks. A Git respository URL
@@ -316,6 +319,7 @@ resources:
             $OS_PASSWORD: {get_param: os_password}
             $OS_TENANT_NAME: {get_param: os_tenant_name}
             $OS_REGION_NAME: {get_param: os_region_name}
+            $LB_TYPE: {get_param: loadbalancer_type}
           template: {get_file: fragments/master-ansible.sh}
 
   # Collect the results from a set of resources

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -1,0 +1,271 @@
+heat_template_version: 2014-10-16
+
+description: >
+  A template which provides a creates a loadbalancer using neutron's LBaaS.
+
+parameters:
+
+  key_name:
+    description: >
+      A pre-submitted SSH key to access the VM hosts
+    type: string
+    constraints:
+    - custom_constraint: nova.keypair
+
+  image:
+    description: >
+      Select a base image to use for the infrastructure server
+    type: string
+    constraints:
+    - custom_constraint: glance.image
+
+  flavor:
+    description: >
+      Define the hardware characteristics for the VMs: CPU, Memory, base disk
+    type: string
+    constraints:
+    - custom_constraint: nova.flavor
+
+  hostname:
+    description: >
+      The load balancer hostname portion of the FQDN
+    type: string
+
+  domain_name:
+    description: >
+      All VMs will be placed in this domain
+    type: string
+
+  rhn_username:
+    description: >
+      A valid user with entitlements to RHEL and OpenShift software repos
+    type: string
+
+  rhn_password:
+    description: >
+      The password for the RHN user
+    type: string
+    hidden: true
+
+  rhn_pool:
+    description: >
+      A subscription pool containing the RHEL and OpenShift software repos
+      OPTIONAL
+    type: string
+    hidden: true
+
+  dns_ip:
+    description: IP address of the DNS server
+    type: string
+
+  ssh_user:
+    description: >
+      The user for SSH access to the VM hosts
+    type: string
+
+  ansible_public_key:
+    description: >
+      The SSH public key that Ansible will use to access master and node hosts
+      This will be placed on each VM host in /root/.ssh/authorized_keys
+    type: string
+
+  fixed_subnet:
+    description: >
+      The name or ID of the internal IPv4 space
+    type: string
+    constraints:
+    - custom_constraint: neutron.subnet
+
+  members:
+    type: comma_delimited_list
+
+  master_hostname:
+    type: string
+
+  floatingip_id:
+    type: string
+
+  fixed_network:
+    description: >
+      The name or ID of the internal network
+    type: string
+    constraints:
+    - custom_constraint: neutron.network
+
+  fixed_subnet:
+    description: >
+      The name or ID of the internal IPv4 space
+    type: string
+    constraints:
+    - custom_constraint: neutron.subnet
+
+  extra_repository_urls:
+    type: comma_delimited_list
+    description: List of repository URLs which will be installed on each node.
+    default: ''
+
+  # Delay openshift installation until the master is ready to accept
+  timeout:
+    description: Time to wait until the master setup is ready.
+    type: number
+    default: 4000
+
+resources:
+  floating_ip_assoc:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      port_id: {get_resource: port}
+      floatingip_id: {get_param: floatingip_id}
+
+  # bind the IP to the host with security port filters
+  port:
+    type: OS::Neutron::Port
+    properties:
+      security_groups:
+      - {get_resource: security_group}
+      network: {get_param: fixed_network}
+      fixed_ips:
+      - subnet: {get_param: fixed_subnet}
+      replacement_policy: AUTO
+
+  # Define network access policy for access to the laod balancer
+  security_group:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+      - protocol: icmp
+      - protocol: tcp
+        port_range_min: 8443
+        port_range_max: 8443
+      - protocol: tcp
+        port_range_min: 22
+        port_range_max: 22
+
+  # The VM which will host the load balancer service
+  host:
+    type: OS::Nova::Server
+    properties:
+      name:
+        str_replace:
+          template: "%stackname%-%hostname%"
+          params:
+            '%stackname%': {get_param: 'OS::stack_name'}
+            '%hostname%': {get_param: hostname}
+      admin_user: {get_param: ssh_user}
+      image: {get_param: image}
+      flavor: {get_param: flavor}
+      key_name: {get_param: key_name}
+      networks:
+      - port: {get_resource: port}
+      user_data_format: SOFTWARE_CONFIG
+      user_data: {get_resource: init}
+
+  # Collect a set of host configuration information in a single structure
+  init:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+      - config: {get_resource: set_hostname}
+      - config: {get_resource: included_files}
+      - config: {get_resource: rhn_register}
+      - config: {get_resource: set_extra_repos}
+      - config: {get_resource: host_update}
+      - config: {get_resource: lb_boot}
+
+  # Compose the FQDN and set the hostname in the cloud-init data structure
+  set_hostname:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        hostname: {get_param: hostname}
+        fqdn:
+          str_replace:
+            template: "HOST.DOMAIN"
+            params:
+              HOST: {get_param: hostname}
+              DOMAIN: {get_param: domain_name}
+
+  # Compile a set of standard configuration files to provide identity and access
+  included_files:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        write_files:
+        - path: /usr/bin/retry
+          permissions: 0755
+          content: {get_file: fragments/retry.sh}
+        ssh_authorized_keys:
+        - {get_param: ansible_public_key}
+
+  # Connect to a software source for updates on RHEL
+  rhn_register:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $RHN_USERNAME: {get_param: rhn_username}
+            $RHN_PASSWORD: {get_param: rhn_password}
+            $POOL_ID: {get_param: rhn_pool}
+          template: {get_file: fragments/rhn-register.sh}
+
+  # Enable any extra repositories
+  set_extra_repos:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $REPOLIST:
+              list_join:
+                - " "
+                - {get_param: extra_repository_urls}
+          template: {get_file: fragments/set-extra-repos.sh}
+
+  # Insure that the host software is current
+  host_update:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        get_file: fragments/host-update.sh
+
+  # Prepare the host for SSH access for ansible
+  lb_boot:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $DNS_IP: {get_param: dns_ip}
+            $WC_NOTIFY: { get_attr: ['wait_handle', 'curl_cli'] }
+          template: {get_file: fragments/lb-boot.sh}
+
+  # Wait for the load balancer host to complete cloud-init or time out
+  wait_condition:
+    type: OS::Heat::WaitCondition
+    properties:
+      handle: {get_resource: wait_handle}
+      timeout: {get_param: timeout}
+
+  # Provide a curl CLI to the cloud-init script.  On completion, notify Heat
+  wait_handle:
+    type: OS::Heat::WaitConditionHandle
+
+outputs:
+  console_url:
+    description: URL of the OpenShift web console
+    value:
+      str_replace:
+        template: "https://%hostname%.%domainname%:8443/console/"
+        params:
+          '%hostname%': {get_param: hostname}
+          '%domainname%': {get_param: domain_name}
+
+  api_url:
+    description: URL entrypoint to the OpenShift API
+    value:
+      str_replace:
+        template: "https://%hostname%.%domainname%:8443/"
+        params:
+          '%hostname%': {get_param: hostname}
+          '%domainname%': {get_param: domain_name}

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -1,0 +1,157 @@
+heat_template_version: 2014-10-16
+
+description: >
+  A template which provides a creates a loadbalancer using neutron's LBaaS.
+
+parameters:
+
+  key_name:
+    description: >
+      A pre-submitted SSH key to access the VM hosts
+    type: string
+    constraints:
+    - custom_constraint: nova.keypair
+
+  image:
+    type: string
+    default: ''
+
+  flavor:
+    description: >
+      Define the hardware characteristics for the VMs: CPU, Memory, base disk
+    type: string
+    constraints:
+    - custom_constraint: nova.flavor
+
+  hostname:
+    description: >
+      The load balancer hostname portion of the FQDN
+    type: string
+
+  domain_name:
+    description: >
+      All VMs will be placed in this domain
+    type: string
+
+  rhn_username:
+    description: >
+      A valid user with entitlements to RHEL and OpenShift software repos
+    type: string
+
+  rhn_password:
+    description: >
+      The password for the RHN user
+    type: string
+    hidden: true
+
+  rhn_pool:
+    description: >
+      A subscription pool containing the RHEL and OpenShift software repos
+      OPTIONAL
+    type: string
+    hidden: true
+
+  dns_ip:
+    description: IP address of the DNS server
+    type: string
+
+  ssh_user:
+    description: >
+      The user for SSH access to the VM hosts
+    type: string
+
+  ansible_public_key:
+    description: >
+      The SSH public key that Ansible will use to access master and node hosts
+      This will be placed on each VM host in /root/.ssh/authorized_keys
+    type: string
+
+  fixed_subnet:
+    description: >
+      The name or ID of the internal IPv4 space
+    type: string
+    constraints:
+    - custom_constraint: neutron.subnet
+
+  members:
+    type: comma_delimited_list
+
+  master_hostname:
+    type: string
+
+  floatingip_id:
+    type: string
+
+  fixed_network:
+    description: >
+      The name or ID of the internal network
+    type: string
+    constraints:
+    - custom_constraint: neutron.network
+
+  fixed_subnet:
+    description: >
+      The name or ID of the internal IPv4 space
+    type: string
+    constraints:
+    - custom_constraint: neutron.subnet
+
+  extra_repository_urls:
+    type: comma_delimited_list
+    description: List of repository URLs which will be installed on each node.
+    default: ''
+
+resources:
+  lb:
+    type: OS::Neutron::LoadBalancer
+    properties:
+      protocol_port: 8443
+      pool_id: {get_resource: lb_pool}
+      members: {get_param: members}
+
+  lb_pool:
+    type: OS::Neutron::Pool
+    properties:
+      name: lb_pool
+      description: Load balancer for OpenShift hosts.
+      protocol: HTTPS
+      subnet_id: {get_param: fixed_subnet}
+      lb_method: ROUND_ROBIN
+      monitors: [{get_resource: lb_monitor}]
+      vip:
+        protocol_port: 8443
+        session_persistence:
+          type: SOURCE_IP
+
+  lb_monitor:
+    type: OS::Neutron::HealthMonitor
+    properties:
+      type: TCP
+      delay: 15
+      max_retries: 5
+      timeout: 10
+
+  floating_ip_assoc:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      port_id: {get_attr: [lb_pool, vip, port_id]}
+      floatingip_id: {get_param: floatingip_id}
+
+outputs:
+  console_url:
+    description: URL of the OpenShift web console
+    value:
+      str_replace:
+        template: "https://%hostname%.%domainname%:8443/console/"
+        params:
+          '%hostname%': {get_param: hostname}
+          '%domainname%': {get_param: domain_name}
+
+  api_url:
+    description: URL entrypoint to the OpenShift API
+    value:
+      str_replace:
+        template: "https://%hostname%.%domainname%:8443/"
+        params:
+          '%hostname%': {get_param: hostname}
+          '%domainname%': {get_param: domain_name}

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -1,0 +1,127 @@
+heat_template_version: 2014-10-16
+
+description: >
+  A template which provides a creates a loadbalancer using neutron's LBaaS.
+
+parameters:
+
+  key_name:
+    description: >
+      A pre-submitted SSH key to access the VM hosts
+    type: string
+    constraints:
+    - custom_constraint: nova.keypair
+
+  image:
+    type: string
+    default: ''
+
+  flavor:
+    description: >
+      Define the hardware characteristics for the VMs: CPU, Memory, base disk
+    type: string
+    constraints:
+    - custom_constraint: nova.flavor
+
+  hostname:
+    description: >
+      The load balancer hostname portion of the FQDN
+    type: string
+
+  domain_name:
+    description: >
+      All VMs will be placed in this domain
+    type: string
+
+  rhn_username:
+    description: >
+      A valid user with entitlements to RHEL and OpenShift software repos
+    type: string
+
+  rhn_password:
+    description: >
+      The password for the RHN user
+    type: string
+    hidden: true
+
+  rhn_pool:
+    description: >
+      A subscription pool containing the RHEL and OpenShift software repos
+      OPTIONAL
+    type: string
+    hidden: true
+
+  dns_ip:
+    description: IP address of the DNS server
+    type: string
+
+  ssh_user:
+    description: >
+      The user for SSH access to the VM hosts
+    type: string
+
+  ansible_public_key:
+    description: >
+      The SSH public key that Ansible will use to access master and node hosts
+      This will be placed on each VM host in /root/.ssh/authorized_keys
+    type: string
+
+  fixed_subnet:
+    description: >
+      The name or ID of the internal IPv4 space
+    type: string
+    constraints:
+    - custom_constraint: neutron.subnet
+
+  members:
+    type: comma_delimited_list
+
+  master_hostname:
+    type: string
+
+  floatingip_id:
+    type: string
+
+  fixed_network:
+    description: >
+      The name or ID of the internal network
+    type: string
+    constraints:
+    - custom_constraint: neutron.network
+
+  fixed_subnet:
+    description: >
+      The name or ID of the internal IPv4 space
+    type: string
+    constraints:
+    - custom_constraint: neutron.subnet
+
+  extra_repository_urls:
+    type: comma_delimited_list
+    description: List of repository URLs which will be installed on each node.
+    default: ''
+
+  # Delay openshift installation until the master is ready to accept
+  timeout:
+    description: Time to wait until the master setup is ready.
+    type: number
+    default: 4000
+
+outputs:
+  console_url:
+    description: URL of the OpenShift web console
+    value:
+      str_replace:
+        template: "https://%hostname%.%domainname%:8443/console/"
+        params:
+          '%hostname%': {get_param: master_hostname}
+          '%domainname%': {get_param: domain_name}
+
+  api_url:
+    description: URL entrypoint to the OpenShift API
+    value:
+      str_replace:
+        template: "https://%hostname%.%domainname%:8443/"
+        params:
+          '%hostname%': {get_param: master_hostname}
+          '%domainname%': {get_param: domain_name}

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -27,6 +27,13 @@ parameters:
     constraints:
     - custom_constraint: glance.image
 
+  loadbalancer_image:
+    description: >
+      Select a base image to use for the loadbalancer nodes, this is required
+      only if 'dedicated' loadbalancer_type is used.
+    type: string
+    default: ''
+
   flavor:
     type: string
     description: The Nova flavor to use for the OpenShift nodes
@@ -57,6 +64,15 @@ parameters:
   skip_dns:
     type: boolean
     default: false
+
+  loadbalancer_type:
+    type: string
+    default: neutron
+    constraints:
+      - allowed_values:
+        - neutron
+        - dedicated
+        - none
 
   master_count:
     type: number
@@ -321,6 +337,7 @@ resources:
       os_tenant_name: {get_param: os_tenant_name}
       os_region_name: {get_param: os_region_name}
       skip_dns: {get_param: skip_dns}
+      loadbalancer_type: {get_param: loadbalancer_type}
       extra_repository_urls: {get_param: extra_repository_urls}
       lb_ip: {get_attr: [lb_floating_ip, floating_ip_address]}
       lb_hostname:
@@ -519,40 +536,32 @@ resources:
         port_range_min: 0
         port_range_max: 65535
 
-  lb:
-    type: OS::Neutron::LoadBalancer
-    properties:
-      protocol_port: 8443
-      pool_id: {get_resource: lb_pool}
-      members: {get_attr: [openshift_masters, host]}
-
-  lb_pool:
-    type: OS::Neutron::Pool
-    properties:
-      name: lb_pool
-      description: Load balancer for OpenShift hosts.
-      protocol: HTTPS
-      subnet_id: {get_resource: fixed_subnet}
-      lb_method: ROUND_ROBIN
-      monitors: [{get_resource: lb_monitor}]
-      vip:
-        protocol_port: 8443
-        session_persistence:
-          type: SOURCE_IP
-
-  lb_monitor:
-    type: OS::Neutron::HealthMonitor
-    properties:
-      type: TCP
-      delay: 15
-      max_retries: 5
-      timeout: 10
-
   lb_floating_ip:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network: {get_param: external_network}
-      port_id: {get_attr: [lb_pool, vip, port_id]}
+
+  loadbalancer:
+    type:  OOShift::LoadBalancer
+    properties:
+      image: {get_param: loadbalancer_image}
+      flavor: {get_param: flavor}
+      key_name: {get_param: ssh_key_name}
+      ssh_user: {get_param: ssh_user}
+      rhn_username: {get_param: rhn_username}
+      rhn_password: {get_param: rhn_password}
+      rhn_pool: {get_param: rhn_pool}
+      hostname: {get_param: lb_hostname}
+      domain_name: {get_param: domain_name}
+      ansible_public_key: {get_attr: [ansible_keys, public_key]}
+      dns_ip: {get_attr: [infra_floating_ip, floating_ip_address]}
+      fixed_subnet: {get_resource: fixed_subnet}
+      members: {get_attr: [openshift_masters, host]}
+      master_hostname: {get_attr: [openshift_masters, resource.0.hostname]}
+      floatingip_id: {get_resource: lb_floating_ip}
+      fixed_network: {get_resource: fixed_network}
+      fixed_subnet: {get_resource: fixed_subnet}
+      extra_repository_urls: {get_param: extra_repository_urls}
 
 outputs:
   dns_ip:
@@ -565,23 +574,11 @@ outputs:
 
   console_url:
     description: URL of the OpenShift web console
-    value:
-      str_replace:
-        template: "https://%stackname%-%hostname%.%domainname%:8443/console/"
-        params:
-          '%stackname%': {get_param: 'OS::stack_name'}
-          '%hostname%': {get_param: lb_hostname}
-          '%domainname%': {get_param: domain_name}
+    value: {get_attr: [loadbalancer, console_url]}
 
   api_url:
     description: URL entrypoint to the OpenShift API
-    value:
-      str_replace:
-        template: "https://%stackname%-%hostname%.%domainname%:8443/"
-        params:
-          '%stackname%': {get_param: 'OS::stack_name'}
-          '%hostname%': {get_param: lb_hostname}
-          '%domainname%': {get_param: domain_name}
+    value: {get_attr: [loadbalancer, api_url]}
 
   host_ips:
     description: IP addresses of the OpenShift nodes


### PR DESCRIPTION
There are many openstack environments where LBaaS is not available,
this patch allows to deploy a dedicated loadbalancer node on which
loadbalancer service is then installed/configured by openshift-ansible.

Because openshift-ansible doesn't support deploying loadbalancer
if only single master node, loadbalancer can be disabled by using
env_loadbalancer_none.yaml.
