### PR TITLE
kube does not allow underscores

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,8 +148,9 @@ EOF
 # retrieve the Heat template (if you haven't yet)
 git clone https://github.com/redhat-openstack/openshift-on-openstack.git
 
-# create a stack named 'my_openshift
-heat stack-create my_openshift -t 180 \
+# create a stack named 'my-openshift'  Kubernetes does not allow underscores
+# in hostnames.
+heat stack-create my-openshift -t 180 \
   -e openshift_parameters.yaml \
   -f openshift-on-openstack/openshift.yaml
 ```


### PR DESCRIPTION
Updating README to reflect that Kubernetes regex is strict against _:

```
Mar 15 09:29:31 my_openshift_2-openshift-master-1 atomic-openshift-node: I0315 09:29:31.323146    7484 kubelet.go:972] Attempting to register node my_openshift_2-openshift-master-1.example.com
Mar 15 09:29:31 my_openshift_2-openshift-master-1 atomic-openshift-node: I0315 09:29:31.325224    7484 kubelet.go:975] Unable to register my_openshift_2-openshift-master-1.example.com with the apiserver: Node "my_openshift_2-openshift-master-1.example.com" is invalid: metadata.name: invalid value 'my_openshift_2-openshift-master-1.example.com', Details: must be a DNS subdomain (at most 253 characters, matching regex [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*): e.g. "example.com"
```
