### PR TITLE
Unify extra repo names

### DIFF
--- a/fragments/set-extra-repos.sh
+++ b/fragments/set-extra-repos.sh
@@ -6,5 +6,6 @@ set -o pipefail
 [ -z "$REPOLIST" ] && exit 0
 cd /etc/yum.repos.d
 for repo in $REPOLIST;do
-    curl -O $repo
+    fname=`echo "$repo"|md5sum |awk '{ print $1}'`.repo
+    curl -o $fname $repo
 done


### PR DESCRIPTION
If multiple extra repos are specified it might be that filename part
is identical for some of them which causes that some repos may
be overwritten. URL's md5sum is now used instead to avoid filename
conflicts.
