### PR TITLE
Run ansible only once

### DIFF
--- a/infra.yaml
+++ b/infra.yaml
@@ -262,6 +262,12 @@ parameters:
     description: List of repository URLs which will be installed on each node.
     default: ''
 
+  node_count:
+    type: number
+    description: >
+      Number of non-master nodes to create.
+    default: 1
+
 resources:
 
   # A VM to provide host based orchestration and other sub-services
@@ -325,6 +331,7 @@ resources:
             $OS_TENANT_NAME: {get_param: os_tenant_name}
             $OS_REGION_NAME: {get_param: os_region_name}
             $LB_TYPE: {get_param: loadbalancer_type}
+            $NODE_COUNT: {get_param: node_count}
           template: {get_file: fragments/master-ansible.sh}
 
   # Collect the results from a set of resources

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -346,6 +346,7 @@ resources:
           params:
             '%stackname%': {get_param: 'OS::stack_name'}
             '%hostname%': {get_param: lb_hostname}
+      node_count: {get_param: node_count}
 
   openshift_masters:
     depends_on: external_router_interface


### PR DESCRIPTION
The main ansible script is triggered on each node addition.
Run ansible only on the last added node (we can get desired number
of nodes from node_count param).
