### PR TITLE
Fix region setting

### DIFF
--- a/infra.yaml
+++ b/infra.yaml
@@ -415,9 +415,6 @@ resources:
         - path: /root/.ssh/id_rsa.pub
           permissions: 0600
           content: {get_param: ansible_public_key}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/nodes.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/group_vars/nodes.yml}
         - path: /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/masters.yml
           permissions: 0644
           content: {get_file: templates/var/lib/ansible/group_vars/masters.yml}

--- a/templates/var/lib/ansible/group_vars/masters.yml
+++ b/templates/var/lib/ansible/group_vars/masters.yml
@@ -1,8 +1,5 @@
 num_infra: {{master_count}}
 openshift_schedulable: true
-openshift_node_labels:
-  region: infra
-  zone: default
 {{#deploy_registry}}
 openshift_registry_selector: region=infra
 {{/deploy_registry}}

--- a/templates/var/lib/ansible/group_vars/nodes.yml
+++ b/templates/var/lib/ansible/group_vars/nodes.yml
@@ -1,3 +1,0 @@
-openshift_node_labels:
-  region: primary
-  zone: default

--- a/templates/var/lib/ansible/inventory
+++ b/templates/var/lib/ansible/inventory
@@ -22,8 +22,8 @@ lb
 
 [nodes]
 {{#masters}}
-{{.}}.{{domainname}}
+{{.}}.{{domainname}} openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 {{/masters}}
 {{#nodes}}
-{{.}}
+{{.}} openshift_node_labels="{'region': 'primary', 'zone': 'default'}"
 {{/nodes}}


### PR DESCRIPTION
Putting region setting into 'nodes' group_vars didn't work well
because both master and openshift nodes are in [nodes] section
in inventory so all nodes have set primary region which causes
that router/registry pods don't start.
