### PR TITLE
Disable dnsmasq setup on nodes

### DIFF
--- a/templates/var/lib/ansible/group_vars/OSv3.yml
+++ b/templates/var/lib/ansible/group_vars/OSv3.yml
@@ -5,6 +5,7 @@ osm_default_subdomain: cloudapps.{{domainname}} # default subdomain to use for e
 openshift_override_hostname_check: true
 openshift_use_openshift_sdn: {{openshift_use_openshift_sdn}}
 openshift_use_flannel: {{openshift_use_flannel}}
+openshift_use_dnsmasq: false
 {{#master_ha}}
 openshift_master_cluster_password: openshift_cluster
 openshift_master_cluster_method: native


### PR DESCRIPTION
If enabled (default) it causes (in containerized deployment)
that dnsmasq is started on each node and resolv.conf is
overwritten to point to the node itself.
