### PR TITLE
Run ansible only once

### DIFF
--- a/fragments/infra-node-add.sh
+++ b/fragments/infra-node-add.sh
@@ -18,6 +18,12 @@ set -eux
 # MAIN
 # ============================================================================
 
+
+NODESFILE=/var/lib/ansible/${node_type}_list
+mkdir -p /var/lib/ansible/
+touch $NODESFILE
+grep -q "$node_hostname" $NODESFILE || echo $node_hostname >> $NODESFILE
+
 [ "$SKIP_DNS" = "True" ] && exit 0
 
 # Check for Atomic Host

--- a/fragments/infra-node-cleanup.sh
+++ b/fragments/infra-node-cleanup.sh
@@ -42,7 +42,7 @@ INVENTORY=/var/lib/ansible/inventory
         -a "oc --config ~/.kube/config delete node $node_name" || true
 
 # remove from the local list
-NODESFILE=/var/lib/ansible/openshift_nodes
+NODESFILE=/var/lib/ansible/node_list
 if [ -e $NODESFILE ]; then
     cp $NODESFILE{,.bkp}
     grep -v "$node_name" ${NODESFILE}.bkp > $NODESFILE || true

--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -6,7 +6,7 @@ set -x
 set -o pipefail
 
 INVENTORY=/var/lib/ansible/inventory
-NODESFILE=/var/lib/ansible/openshift_nodes
+NODESFILE=/var/lib/ansible/node_list
 
 function create_metadata_json() {
     # $1 - metadata filename
@@ -83,7 +83,6 @@ mkdir -p /var/lib/ansible/group_vars
 mkdir -p /var/lib/ansible/host_vars
 
 touch $NODESFILE
-grep -q "$node_hostname" $NODESFILE || echo $node_hostname >> $NODESFILE
 
 create_metadata_json /var/lib/ansible/metadata.json
 

--- a/infra.yaml
+++ b/infra.yaml
@@ -508,6 +508,8 @@ resources:
       group: script
       inputs:
       - name: node_etc_host
+      - name: node_hostname
+      - name: node_type
       outputs:
       - name: result
       config:

--- a/node.yaml
+++ b/node.yaml
@@ -357,6 +357,14 @@ resources:
       server:
         get_param: infra_node
       input_values:
+        node_type: node
+        node_hostname:
+          str_replace:
+            template: "HOST-SUFFIX.DOMAIN"
+            params:
+              HOST: {get_param: hostname}
+              SUFFIX: {get_attr: [random_hostname_suffix, value]}
+              DOMAIN: {get_param: domain_name}
         node_etc_host:
           str_replace:
               template: "IP HOST-SUFFIX.DOMAIN HOST-SUFFIX #openshift"


### PR DESCRIPTION
Openshift nodes are written into nodes list in a separate SWConfig
which causes there is a reasonable time window between registering
all newely create nodes and the SWConfig which runs ansible ->
thanks to this the ansible runs only once instead of per each node.
