### PR TITLE
Restart node service after ansible deployment

### DIFF
--- a/templates/var/lib/ansible/playbooks/main.yml
+++ b/templates/var/lib/ansible/playbooks/main.yml
@@ -1,7 +1,8 @@
+{{=<% %>=}}
 - include: /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
-{{#deploy_router_or_registry}}
+<%#deploy_router_or_registry%>
 - include: /var/lib/ansible/playbooks/services.yml
-{{/deploy_router_or_registry}}
+<%/deploy_router_or_registry%>
 
 - hosts: masters
   sudo: yes
@@ -15,11 +16,19 @@
   - name: Fetch cert file
     fetch:
       src=/etc/origin/master/ca.crt
-      dest={{heat_outputs_path}}.ca_cert
+      dest=<%heat_outputs_path%>.ca_cert
       flat=yes
 
   - name: Fetch ca key
     fetch:
       src=/etc/origin/master/ca.key
-      dest={{heat_outputs_path}}.ca_key
+      dest=<%heat_outputs_path%>.ca_key
       flat=yes
+
+- hosts: nodes
+  sudo: yes
+  tasks:
+  - name: Restart node service
+    service: name={{openshift.common.service_type}}-node state=restarted
+
+<%={{ }}=%>


### PR DESCRIPTION
For some reason after deployment openshift all pods (especially
router pod created during ansible run) are stuck in ContainerCreating
stage forever. It seems the reason is that kubernetes fail to get
PLEG events from docker service, although docker containers of
router service are properly up and running.

Restarting node service works around this issue for now.
