### PR TITLE
EXTRA_POOL_IDS requires a dollar sign $ for existance test

### DIFF
--- a/fragments/rhn-register.sh
+++ b/fragments/rhn-register.sh
@@ -34,7 +34,7 @@ else
     subscription-manager attach --auto
 fi
 
-if [ -n "EXTRA_POOL_IDS" ]; then
+if [ -n "$EXTRA_POOL_IDS" ]; then
     subscription-manager attach --pool $EXTRA_POOL_IDS
 fi
 


### PR DESCRIPTION
The fragments/rhn-register.sh script fails causing the YUM repos to be incorrectly set.
