### PR TITLE
Set explicitly master api port

### DIFF
--- a/templates/var/lib/ansible/group_vars/masters.yml
+++ b/templates/var/lib/ansible/group_vars/masters.yml
@@ -1,5 +1,6 @@
 num_infra: {{master_count}}
 openshift_schedulable: true
+openshift_master_api_port: 8443
 {{#deploy_router}}
 openshift_router_selector: region=infra
 {{/deploy_router}}


### PR DESCRIPTION
Otherwise port 80 is used on dedicated loadbalancer.
