### PR TITLE
Explicitly call openshift_facts in dns playbook

### DIFF
--- a/templates/var/lib/ansible/playbooks/dns.yml
+++ b/templates/var/lib/ansible/playbooks/dns.yml
@@ -49,6 +49,8 @@
   connection: local
   vars:
     ansible_sudo: false
+  roles:
+    - openshift_facts
   tasks:
     - copy:
         src: "/var/lib/ansible/templates/etc/resolv.conf"


### PR DESCRIPTION
Otherwise is_containerized variable may not be set.

Fixes: #132
