### PR TITLE
Refer docker volume by volume-id

### DIFF
--- a/fragments/infra-boot.sh
+++ b/fragments/infra-boot.sh
@@ -24,7 +24,9 @@ set -o pipefail
 # CONSTANTS
 #
 # The device to mount to store Docker images and containers
-DOCKER_VOLUME_DEVICE=/dev/vdb
+VOLUME_ID=$DOCKER_VOLUME_ID
+# docker-storage-setup can not deal with /dev/disk/by-id/ symlinks
+DOCKER_VOLUME_DEVICE=$(readlink -f /dev/disk/by-id/virtio-${VOLUME_ID:0:20})
 
 # The auxiliary service container images - for Atomic hosts
 HEAT_AGENT_CONTAINER_IMAGE=jprovaznik/ooshift-heat-agent

--- a/fragments/master-boot.sh
+++ b/fragments/master-boot.sh
@@ -10,7 +10,9 @@
 # CONSTANTS
 #
 # The device to mount to store Docker images and containers
-DOCKER_VOLUME_DEVICE=/dev/vdb
+VOLUME_ID=$DOCKER_VOLUME_ID
+# docker-storage-setup can not deal with /dev/disk/by-id/ symlinks
+DOCKER_VOLUME_DEVICE=$(readlink -f /dev/disk/by-id/virtio-${VOLUME_ID:0:20})
 
 # Exit on first fail or on reference to an undefined variable
 set -eu

--- a/fragments/node-boot.sh
+++ b/fragments/node-boot.sh
@@ -10,7 +10,9 @@
 # CONSTANTS
 #
 # The device to mount to store Docker images and containers
-DOCKER_VOLUME_DEVICE=/dev/vdb
+VOLUME_ID=$DOCKER_VOLUME_ID
+# docker-storage-setup can not deal with /dev/disk/by-id/ symlinks
+DOCKER_VOLUME_DEVICE=$(readlink -f /dev/disk/by-id/virtio-${VOLUME_ID:0:20})
 
 # Exit on first fail or on reference to an undefined variable
 set -eu

--- a/infra.yaml
+++ b/infra.yaml
@@ -407,6 +407,7 @@ resources:
             $OPENSHIFT_ANSIBLE_GIT_URL: {get_param: openshift_ansible_git_url}
             $OPENSHIFT_ANSIBLE_GIT_REV: {get_param: openshift_ansible_git_rev}
             $WC_NOTIFY: { get_attr: ['wait_handle', 'curl_cli'] }
+            $DOCKER_VOLUME_ID: {get_resource: docker_volume}
           template: {get_file: fragments/infra-boot.sh}
 
   # Compose the FQDN for cloud-init

--- a/master.yaml
+++ b/master.yaml
@@ -393,6 +393,7 @@ resources:
             $SKIP_DNS: {get_param: skip_dns}
             $MASTER_IP: {get_attr: [floating_ip, floating_ip_address]}
             $WC_NOTIFY: { get_attr: ['wait_handle', 'curl_cli'] }
+            $DOCKER_VOLUME_ID: {get_resource: docker_volume}
           template: {get_file: fragments/master-boot.sh}
 
   # Add the hostname and address of the infrastructure host to the master host

--- a/node.yaml
+++ b/node.yaml
@@ -331,6 +331,7 @@ resources:
             $DNS_IP: {get_param: dns_ip}
             $SKIP_DNS: {get_param: skip_dns}
             $WC_NOTIFY: { get_attr: ['wait_handle', 'curl_cli'] }
+            $DOCKER_VOLUME_ID: {get_resource: docker_volume}
           template: {get_file: fragments/node-boot.sh}
 
   # Create a network connection on the fixed network and apply security


### PR DESCRIPTION
Currently we expect that a docker volume is always mapped to /dev/vdb
but sometimes it happens that systemd and docker volumes are swapped,
IOW docker volume is /dev/vda. This causes that randomly deployment may
fail on docker-storage-setup. Using volume-id mitigates this issue.
