### PR TITLE
Fix console/api_urls

### DIFF
--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -114,6 +114,10 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
+  stack_name:
+    type: string
+    default: ''
+
   # Delay openshift installation until the master is ready to accept
   timeout:
     description: Time to wait until the master setup is ready.
@@ -159,7 +163,7 @@ resources:
         str_replace:
           template: "%stackname%-%hostname%"
           params:
-            '%stackname%': {get_param: 'OS::stack_name'}
+            '%stackname%': {get_param: stack_name}
             '%hostname%': {get_param: hostname}
       admin_user: {get_param: ssh_user}
       image: {get_param: image}
@@ -285,7 +289,7 @@ outputs:
       str_replace:
         template: "https://%stackname%-%hostname%.%domainname%:8443/console/"
         params:
-          '%stackname%': {get_param: 'OS::stack_name'}
+          '%stackname%': {get_param: stack_name}
           '%hostname%': {get_param: hostname}
           '%domainname%': {get_param: domain_name}
 
@@ -295,6 +299,6 @@ outputs:
       str_replace:
         template: "https://%stackname%-%hostname%.%domainname%:8443/"
         params:
-          '%stackname%': {get_param: 'OS::stack_name'}
+          '%stackname%': {get_param: stack_name}
           '%hostname%': {get_param: hostname}
           '%domainname%': {get_param: domain_name}

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -111,6 +111,10 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
+  stack_name:
+    type: string
+    default: ''
+
 resources:
   lb:
     type: OS::Neutron::LoadBalancer
@@ -154,7 +158,7 @@ outputs:
       str_replace:
         template: "https://%stackname%-%hostname%.%domainname%:8443/console/"
         params:
-          '%stackname%': {get_param: 'OS::stack_name'}
+          '%stackname%': {get_param: stack_name}
           '%hostname%': {get_param: hostname}
           '%domainname%': {get_param: domain_name}
 
@@ -164,6 +168,6 @@ outputs:
       str_replace:
         template: "https://%stackname%-%hostname%.%domainname%:8443/"
         params:
-          '%stackname%': {get_param: 'OS::stack_name'}
+          '%stackname%': {get_param: stack_name}
           '%hostname%': {get_param: hostname}
           '%domainname%': {get_param: domain_name}

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -117,6 +117,10 @@ parameters:
     type: number
     default: 4000
 
+  stack_name:
+    type: string
+    default: ''
+
 outputs:
   console_url:
     description: URL of the OpenShift web console

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -620,6 +620,7 @@ resources:
       fixed_subnet: {get_resource: fixed_subnet}
       extra_repository_urls: {get_param: extra_repository_urls}
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
+      stack_name: {get_param: 'OS::stack_name'}
 
 outputs:
   dns_ip:


### PR DESCRIPTION
Stack-name is part of loadbalancer name, the problem is that nested
stacks respect nested names, not top-level names.
