### PR TITLE
Move port_security_enabled under properties

### DIFF
--- a/sdn_flannel.yaml
+++ b/sdn_flannel.yaml
@@ -31,8 +31,7 @@ resources:
       fixed_ips:
       - subnet: {get_param: subnet}
       replacement_policy: AUTO
-      value_specs:
-        port_security_enabled: false
+      port_security_enabled: false
 
 outputs:
   port:


### PR DESCRIPTION
There was probably a change in heat which caused that
port_security_enabled is now expected to be under properties
instead under value_specs.
