### PR TITLE
Open kubelet port

### DIFF
--- a/openshift.yaml
+++ b/openshift.yaml
@@ -613,6 +613,10 @@ resources:
         port_range_max: 8053
       - direction: ingress
         protocol: tcp
+        port_range_min: 10250
+        port_range_max: 10250
+      - direction: ingress
+        protocol: tcp
         port_range_min: 24224
         port_range_max: 24224
       - direction: ingress


### PR DESCRIPTION
The port 10250 needs to be open to be able to display the logs of a pod
