### PR TITLE
Epel 7-minor auto fallback to epel-release-latest-7

### DIFF
--- a/customize-disk-image
+++ b/customize-disk-image
@@ -93,7 +93,7 @@ if args.update:
     cmd += ["--update"]
 
 cmd += ["--install", "http://dl.fedoraproject.org/pub/epel/7/x86_64/e/"
-                     "epel-release-7-6.noarch.rpm"]
+                     "epel-release-7-7.noarch.rpm"]
 
 cmd += ["--install", ",".join(args.packages)]
 

--- a/fragments/infra-boot.sh
+++ b/fragments/infra-boot.sh
@@ -48,6 +48,7 @@ function notify_failure() {
     exit 1
 }
 
+
 # 
 # --- DNS functions ----------------------------------------------------------
 #
@@ -151,7 +152,15 @@ function install_epel_repos_disabled() {
     then
         yum -y install \
             ${EPEL_REPO_URL}/e/epel-release-$1.noarch.rpm ||
-            notify_failure "could not install EPEL release $1"
+            echo "Failed to find epel-release-$1.  Installing epel-release-latest-7."
+    fi
+
+    # If it fails, get the latest
+    if ! rpm -q epel-release-$1
+    then
+        yum -y install \
+            https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm ||
+            notify_failure "could not install EPEL release $1 NOR the latest."
     fi
     sed -i -e "s/^enabled=1/enabled=0/" /etc/yum.repos.d/epel.repo
 }

--- a/heat-docker-agent/configure_container_agent.sh
+++ b/heat-docker-agent/configure_container_agent.sh
@@ -15,7 +15,7 @@ yum -y install python-novaclient python-cinderclient
 
 # openshift-ansible
 #RUN yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
+yum -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm || yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum install -y --enablerepo epel ansible1.9
 
 #git clone --single-branch --branch master https://github.com/openshift/openshift-ansible.git  /usr/share/ansible/openshift-ansible/

--- a/templates/var/lib/ansible/playbooks/registry.yml
+++ b/templates/var/lib/ansible/playbooks/registry.yml
@@ -17,7 +17,7 @@
 
   - name: Setup RDO repositories
     yum: name=https://rdoproject.org/repos/rdo-release.rpm state=present
-    when: deployment_type == 'origin' and rpm_check.rc != 0
+    when: deployment_type == 'origin' and rpm_check.rc != 0 and ansible_distribution != 'Red Hat Enterprise Linux'
     when: ansible_first_run | default(false) | bool
 
   - name: Install Nova and Cinder clients


### PR DESCRIPTION
I wrote auto fallback to epel-release-latest-7 because this should not need to be fixed again for this major version.

I just need help fixing the customize-disk-image python to auto fallback

Note: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

@lebauce @markllama 
