### PR TITLE
Add missing resource_registry section into sample env file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -150,6 +150,14 @@ parameters:
    rhn_username: ""
    rhn_password: ""
    rhn_pool: '' # OPTIONAL
+
+resource_registry:
+  # use neutron LBaaS
+  OOShift::LoadBalancer: openshift-on-openstack/loadbalancer_neutron.yaml
+  # use openshift SDN
+  OOShift::ContainerPort: openshift-on-openstack/sdn_openshift_sdn.yaml
+  # enable ipfailover for router setup
+  OOShift::IPFailover: openshift-on-openstack/ipfailover_keepalived.yaml
 EOF
 ```
 


### PR DESCRIPTION
The sample file in README didn't contain required resource_registry
section which caused that some router types were undefined.

Fixes: #172
