### PR TITLE
Allow using different images for infra, master and openshift nodes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -123,7 +123,9 @@ parameters:
    ssh_key_name: default
 
    # Set the image type and size for the VMs
-   server_image: centos72
+   infra_image: centos72
+   master_image: centos72
+   node_image: centos72
    flavor: m1.medium
 
    # Set an existing network for inbound and outbound traffic

--- a/env_aop.yaml
+++ b/env_aop.yaml
@@ -1,6 +1,8 @@
 parameters:
   ssh_key_name: default
-  server_image: rhel71
+  infra_image: rhel72
+  master_image: rhel72
+  node_image: rhel72
   flavor: m1.medium
   external_network: ext_net
   dns_nameserver: 8.8.4.4,8.8.8.8

--- a/env_origin.yaml
+++ b/env_origin.yaml
@@ -1,6 +1,8 @@
 parameters:
   ssh_key_name: default
-  server_image: centos72
+  infra_image: centos72
+  master_image: centos72
+  node_image: centos72
   flavor: m1.medium
   external_network: ext_net
   dns_nameserver: 8.8.4.4,8.8.8.8

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -20,9 +20,21 @@ parameters:
     - custom_constraint: nova.keypair
 
   # VM characteristics
-  server_image:
+  infra_image:
+    type: string
+    description: Name or ID of the infra image registered with Glance
+    constraints:
+    - custom_constraint: glance.image
+
+  master_image:
     type: string
     description: Name or ID of the host image registered with Glance
+    constraints:
+    - custom_constraint: glance.image
+
+  node_image:
+    type: string
+    description: Name or ID of the openshift node image registered with Glance
     constraints:
     - custom_constraint: glance.image
 
@@ -358,7 +370,7 @@ resources:
     depends_on: external_router_interface
     type: infra.yaml
     properties:
-      image: {get_param: server_image}
+      image: {get_param: infra_image}
       flavor: {get_param: flavor}
       key_name: {get_param: ssh_key_name}
       ssh_user: {get_param: ssh_user}
@@ -417,7 +429,7 @@ resources:
       resource_def:
         type: master.yaml
         properties:
-          image: {get_param: server_image}
+          image: {get_param: master_image}
           flavor: {get_param: flavor}
           key_name: {get_param: ssh_key_name}
           ssh_user: {get_param: ssh_user}
@@ -466,7 +478,7 @@ resources:
       resource:
         type: node.yaml
         properties:
-          image: {get_param: server_image}
+          image: {get_param: node_image}
           flavor: {get_param: flavor}
           key_name: {get_param: ssh_key_name}
           ssh_user: {get_param: ssh_user}

--- a/tests/roles/deploy/tasks/main.yml
+++ b/tests/roles/deploy/tasks/main.yml
@@ -12,7 +12,9 @@
             -P flavor=m1.shift
             -P node_count={{node_count | default(2)}}
             -P master_count={{master_count | default(1)}}
-            -P server_image=centos72
+            -P infra_image=centos72
+            -P master_image=centos72
+            -P node_image=centos72
             -P master_server_group_policies=affinity
             -P master_docker_volume_size_gb=6
             -P node_docker_volume_size_gb=5


### PR DESCRIPTION
This allows using prebuilt/gold images for each type of VM.
