### PR TITLE
Optimize scale-up of openshift nodes

### DIFF
--- a/infra.yaml
+++ b/infra.yaml
@@ -461,6 +461,9 @@ resources:
         - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/main.yml
           permissions: 0644
           content: {get_file: templates/var/lib/ansible/playbooks/main.yml}
+        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/scaleup.yml
+          permissions: 0644
+          content: {get_file: templates/var/lib/ansible/playbooks/scaleup.yml}
         - path: /var/lib/os-apply-config/templates/var/lib/ansible/inventory
           permissions: 0644
           content: {get_file: templates/var/lib/ansible/inventory}

--- a/templates/var/lib/ansible/playbooks/scaleup.yml
+++ b/templates/var/lib/ansible/playbooks/scaleup.yml
@@ -1,0 +1,22 @@
+{{=<% %>=}}
+<%^skip_dns%>
+- include: /var/lib/ansible/playbooks/dns.yml
+<%/skip_dns%>
+
+- include: /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/scaleup.yml
+  vars:
+    openshift_infra_nodes: "{{ groups.infra | default([]) }}"
+
+- hosts: nodes
+  sudo: yes
+  tasks:
+  - name: Allow docker traffic
+    shell: iptables -A DOCKER -p tcp -j ACCEPT
+    when: openshift_use_flannel
+
+- hosts: nodes
+  sudo: yes
+  tasks:
+  - name: Restart node service
+    service: name={{openshift.common.service_type}}-node state=restarted
+<%={{ }}=%>


### PR DESCRIPTION
When only "compute" nodes are added we can run shorter "node scaleup"
specific playbook instead of the main one. This is useful for big
deployments.
