### PR TITLE
Create one security group for all "compute" nodes

### DIFF
--- a/node.yaml
+++ b/node.yaml
@@ -56,6 +56,11 @@ parameters:
     constraints:
     - custom_constraint: neutron.subnet
 
+  security_group:
+    description: >
+      ID of the network access policies for the OpenShift node hosts
+    type: string
+
   dns_ip:
     description: IP address of the DNS server which serves this domain
     type: string
@@ -337,36 +342,17 @@ resources:
     type: OS::Neutron::Port
     properties:
       security_groups:
-      - {get_resource: security_group}
+      - {get_param: security_group}
       network: {get_param: fixed_network}
       fixed_ips:
       - subnet: {get_param: fixed_subnet}
       replacement_policy: AUTO
 
-  # Define the network access policy for the node
-  security_group:
-    type: OS::Neutron::SecurityGroup
-    properties:
-      rules:
-      - protocol: icmp
-      - direction: ingress
-        protocol: tcp
-        port_range_min: 22
-        port_range_max: 22
-      - direction: ingress
-        protocol: tcp
-        port_range_min: 10250
-        port_range_max: 10250
-      - direction: ingress
-        protocol: udp
-        port_range_min: 4789
-        port_range_max: 4789
-
   # Create a network connection on the internal communications network
   internal_port:
     type: OOShift::ContainerPort
     properties:
-      security_group: {get_resource: security_group}
+      security_group: {get_param: security_group}
       network: {get_param: internal_network}
       subnet: {get_param: internal_subnet}
 

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -475,6 +475,7 @@ resources:
           fixed_subnet: {get_resource: fixed_subnet}
           internal_network: {get_resource: cluster_network}
           internal_subnet: {get_resource: cluster_subnet}
+          security_group: {get_resource: node_security_group}
           docker_volume_size: {get_param: node_docker_volume_size_gb}
           rhn_username: {get_param: rhn_username}
           rhn_password: {get_param: rhn_password}
@@ -502,6 +503,25 @@ resources:
             list_join:
               - " "
               - {get_attr: [openshift_masters, hostname]}
+
+  # Define the network access policy for openshift nodes
+  node_security_group:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+      - protocol: icmp
+      - direction: ingress
+        protocol: tcp
+        port_range_min: 22
+        port_range_max: 22
+      - direction: ingress
+        protocol: tcp
+        port_range_min: 10250
+        port_range_max: 10250
+      - direction: ingress
+        protocol: udp
+        port_range_min: 4789
+        port_range_max: 4789
 
   # Scaling and Operational Controls
   scale_up_policy:


### PR DESCRIPTION
There was a separate security group for each openshift node. There is
no reason to keep extra group per node, also it caused that secgroup
quota was reached pretty quickly for bigger deployemnts.
