### PR TITLE
Fix pidof ansible detection

### DIFF
--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -113,7 +113,7 @@ for node in `cat $NODESFILE`; do
     create_openshift_node_vars $node
 done
 
-while pidof -x /bin/ansible-playbook; do
+while pidof -x /bin/ansible-playbook /usr/bin/ansible-playbook; do
   echo "waiting for another ansible-playbook to finish"
   sleep 10
 done


### PR DESCRIPTION
It seems /usr/bin/ansible-playbook is now used (/bin/ansible-playbook2
kept for now to be sure).
