### PR TITLE
Switch to ansible 2.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -155,7 +155,7 @@ parameters:
    
    # Currently Ansible 2.1 is not supported so add these parameters as a workaround
    openshift_ansible_git_url: https://github.com/openshift/openshift-ansible.git
-   openshift_ansible_git_rev: 08791978fdf3ee385760761d4fc6bc47febf1732
+   openshift_ansible_git_rev: master
 
 resource_registry:
   # use neutron LBaaS

--- a/customize-disk-image
+++ b/customize-disk-image
@@ -106,8 +106,8 @@ if args.update:
 cmd += ["--install", "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
         "--run-command", "sed -i -e 's/^enabled=1/enabled=0/' /etc/yum.repos.d/epel.repo"]
 
-# Install ansible1.9
-cmd += ["--run-command", "yum -y --enablerepo=epel install ansible1.9"]
+# Install ansible
+cmd += ["--run-command", "yum -y --enablerepo=epel install ansible"]
 
 # Install required packages
 cmd += ["--install", ",".join(args.packages)]

--- a/env_origin.yaml
+++ b/env_origin.yaml
@@ -18,7 +18,7 @@ parameters:
   master_docker_volume_size_gb: 25
   node_docker_volume_size_gb: 25
   openshift_ansible_git_url: https://github.com/openshift/openshift-ansible.git
-  openshift_ansible_git_rev: 08791978fdf3ee385760761d4fc6bc47febf1732
+  openshift_ansible_git_rev: master
 
 resource_registry:
   OOShift::LoadBalancer: loadbalancer_neutron.yaml

--- a/fragments/infra-boot.sh
+++ b/fragments/infra-boot.sh
@@ -238,7 +238,7 @@ else
         install_epel_repos_disabled $EPEL_RELEASE_VERSION
 
         # Install from the EPEL repository
-        retry yum -y --enablerepo=epel install ansible1.9 ||
+        retry yum -y --enablerepo=epel install ansible ||
             notify_failure "could not install ansible"
     else
         retry yum -y install ansible

--- a/heat-docker-agent/configure_container_agent.sh
+++ b/heat-docker-agent/configure_container_agent.sh
@@ -16,7 +16,7 @@ yum -y install python-novaclient python-cinderclient
 # openshift-ansible
 #RUN yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-7.noarch.rpm || yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum install -y --enablerepo epel ansible1.9
+yum install -y --enablerepo epel ansible
 
 #git clone --single-branch --branch master https://github.com/openshift/openshift-ansible.git  /usr/share/ansible/openshift-ansible/
 git clone --single-branch --branch master https://github.com/jprovaznik/openshift-ansible.git  /usr/share/ansible/openshift-ansible/

--- a/templates/var/lib/ansible/group_vars/OSv3.yml
+++ b/templates/var/lib/ansible/group_vars/OSv3.yml
@@ -2,6 +2,7 @@ ansible_first_run: {{ansible_first_run}}
 infra_instance_id: {{infra_instance_id}}
 ansible_ssh_user: {{ssh_user}}
 ansible_sudo: true
+ansible_become: true
 deployment_type: {{deployment_type}} # deployment type valid values are origin, online and openshif-enterprise
 osm_default_subdomain: cloudapps.{{domainname}} # default subdomain to use for exposed routes
 openshift_override_hostname_check: true

--- a/templates/var/lib/ansible/group_vars/masters.yml
+++ b/templates/var/lib/ansible/group_vars/masters.yml
@@ -3,7 +3,7 @@ router_vip: {{router_vip}}
 openshift_schedulable: true
 openshift_master_api_port: 8443
 {{#deploy_router}}
-openshift_router_selector: region=infra
+openshift_hosted_router_selector: region=infra
 {{/deploy_router}}
 {{^deploy_router}}
 openshift_hosted_router_replicas: 0

--- a/templates/var/lib/ansible/playbooks/dns.yml
+++ b/templates/var/lib/ansible/playbooks/dns.yml
@@ -1,26 +1,13 @@
 {{=<% %>=}}
-- include: /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/evaluate_groups.yml
-  vars_files:
-  - /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/cluster_hosts.yml
-
 - name: Gather facts
   hosts: nodes
-  vars_files:
-  - /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/cluster_hosts.yml
-  vars:
-    openshift_deployment_type: "<% deployment_type %>"
-  roles:
-    - { role: 'openshift_common'}
+  gather_facts: False
+  tasks:
+    - setup:
+        filter: ansible_*
 
 - name: Configure the DNS
   hosts: dns
-  vars_files:
-  - /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/cluster_hosts.yml
-  vars:
-    ansible_ssh_user: <%ssh_user%>
-    ansible_sudo: true
-    ansible_pkg_mgr: yum
-    deployment_type: <%deployment_type%>
   roles:
     - { role: '/usr/share/ansible/openshift-ansible/roles/dns',
         base_docker_image: 'centos:centos7',

--- a/templates/var/lib/ansible/playbooks/haproxy.yml
+++ b/templates/var/lib/ansible/playbooks/haproxy.yml
@@ -1,7 +1,14 @@
 {{=<% %>=}}
 - include: /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/evaluate_groups.yml
-  vars_files:
-  - /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/cluster_hosts.yml
+  vars:
+    g_etcd_hosts:   "{{ groups.etcd | default([]) }}"
+    g_lb_hosts:     "{{ groups.lb | default([]) }}"
+    g_master_hosts: "{{ groups.masters | default([]) }}"
+    g_node_hosts:   "{{ groups.nodes | default([]) }}"
+    g_new_node_hosts: "{{ groups.new_nodes | default([]) }}"
+    g_nfs_hosts:   "{{ groups.nfs | default([]) }}"
+    g_all_hosts:    "{{ g_master_hosts | union(g_node_hosts) | union(g_etcd_hosts)
+                        | union(g_lb_hosts) | default([]) }}"
 
 - name: Gather facts
   hosts: masters

--- a/templates/var/lib/ansible/playbooks/ipfailover.yml
+++ b/templates/var/lib/ansible/playbooks/ipfailover.yml
@@ -4,7 +4,7 @@
   sudo: yes
   tasks:
   - name: Deploy Openshift IP failover for router
-    command: oadm ipfailover --create --service-account=router --interface=eth0 --selector='{{ openshift_router_selector }}' --replicas={{ num_infra }} --virtual-ips="{{ router_vip }}" --credentials=/etc/origin/master/openshift-router.kubeconfig
+    command: oadm ipfailover --create --service-account=router --interface=eth0 --selector='region=infra' --replicas={{ num_infra }} --virtual-ips="{{ router_vip }}" --credentials=/etc/origin/master/openshift-router.kubeconfig
     when: ansible_first_run | default(false) | bool
 
 - hosts: masters


### PR DESCRIPTION
Ansible 2.1 is now required by openshift-ansible

Fixes: #181
Fixes: #185
