### PR TITLE
Restart crond service if ansible really runs

### DIFF
--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -97,9 +97,6 @@ function is_scaleup() {
         grep '^[<>]' | grep -v '^< .*-node') && return 1 || return 0
 }
 
-# crond was stopped in cloud-init before yum update, make sure it's running
-systemctl status crond && systemctl restart crond
-
 [ "$skip_ansible" == "True" ] && exit 0
 
 mkdir -p /var/lib/ansible/group_vars
@@ -133,6 +130,9 @@ if [ -e ${INVENTORY}.deployed ] &&
 fi
 
 cp ${INVENTORY} ${INVENTORY}.started
+
+# crond was stopped in cloud-init before yum update, make sure it's running
+systemctl status crond && systemctl restart crond
 
 export HOME=/root
 export ANSIBLE_ROLES_PATH=/usr/share/ansible/openshift-ansible/roles


### PR DESCRIPTION
If many compute nodes is added at the same time, master-ansible script
is triggered many times which causes that crond script is restarted
many time in a short period which causes that the service is marked
as failed by systemd.
