### PR TITLE
Volume and container quotas

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -152,7 +152,7 @@ parameters:
    rhn_username: ""
    rhn_password: ""
    rhn_pool: '' # OPTIONAL
-   
+
    # Currently Ansible 2.1 is not supported so add these parameters as a workaround
    openshift_ansible_git_url: https://github.com/openshift/openshift-ansible.git
    openshift_ansible_git_rev: master
@@ -377,6 +377,21 @@ installation by running
 ```bash
 heat output-show --format=raw my-openshift ca_cert > ca.crt
 heat output-show --format=raw my-openshift ca_key > ca.key
+```
+
+== Container and volumes quotas
+
+OpenShift has preliminary support for local emptyDir volume quotas. You can
+set the `volume_quota` parameter to a resource quantity representing the desired
+quota per FSGroup.
+
+You can set quota on the maximum size of the containers using the
+`container_quota` parameter in GB.
+
+Example:
+```yaml
+   volume_quota: 10
+   container_quota: 20
 ```
 
 [[IPFailover]]

--- a/fragments/common_functions.sh
+++ b/fragments/common_functions.sh
@@ -52,3 +52,10 @@ DEVS=$docker_dev
 VG=docker-vg
 EOF
 }
+
+function docker_set_storage_quota() {
+    echo "EXTRA_DOCKER_STORAGE_OPTIONS=\"--storage-opt dm.basesize=$1G\"" \
+        >> /etc/sysconfig/docker-storage-setup
+    echo "DOCKER_STORAGE_OPTIONS=\"--storage-opt dm.basesize=$1G\"" \
+        > /etc/sysconfig/docker-storage
+}

--- a/fragments/infra-boot.sh
+++ b/fragments/infra-boot.sh
@@ -140,7 +140,7 @@ if is_atomic_host
 then
     systemd_docker_disable_storage_setup
 
-    docker_set_storage_device $DOCKER_VOLUME_ID
+    docker_set_storage_device $VOLUME_ID
 
     systemctl enable lvm2-lvmetad
     systemctl start lvm2-lvmetad

--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -61,7 +61,8 @@ cat << EOF > $1
     "ldap_preferred_username": "$ldap_preferred_username",
     "infra_instance_id": "$infra_instance_id",
     "ansible_first_run": $([ -e ${INVENTORY}.deployed ] && echo false || echo true),
-    "router_vip": "$router_vip"
+    "router_vip": "$router_vip",
+    "volume_quota": $volume_quota
 }
 EOF
 }
@@ -136,7 +137,7 @@ cp ${INVENTORY} ${INVENTORY}.started
 systemctl status crond && systemctl restart crond
 
 export HOME=/root
-export ANSIBLE_ROLES_PATH=/usr/share/ansible/openshift-ansible/roles
+export ANSIBLE_ROLES_PATH=/usr/share/ansible/openshift-ansible/roles:/var/lib/ansible/roles
 export ANSIBLE_HOST_KEY_CHECKING=False
 
 logfile=/var/log/ansible.$$

--- a/fragments/master-boot.sh
+++ b/fragments/master-boot.sh
@@ -38,7 +38,7 @@ then
     systemd_add_docker_socket
 fi
 
-docker_set_storage_device $DOCKER_VOLUME_ID
+docker_set_storage_device $VOLUME_ID
 
 # lvmetad allows new volumes to be configured and made available as they appear
 # This is good for dynamically created volumes in a cloud provider service

--- a/fragments/node-boot.sh
+++ b/fragments/node-boot.sh
@@ -36,14 +36,19 @@ then
     systemd_add_docker_socket
 fi
 
-if [ -n "$VOLUME_ID" ]
-then
-    docker_set_storage_device $DOCKER_VOLUME_ID
-fi
-
 # lvmetad allows new volumes to be configured and made available as they appear
 # This is good for dynamically created volumes in a cloud provider service
 systemctl enable lvm2-lvmetad
 systemctl start lvm2-lvmetad
+
+if [ -n "$VOLUME_ID" ]
+then
+    docker_set_storage_device $VOLUME_ID
+fi
+
+if [ -n "$CONTAINER_QUOTA" ] && [ "$CONTAINER_QUOTA" != 0 ]
+then
+    docker_set_storage_quota $CONTAINER_QUOTA
+fi
 
 notify_success "OpenShift node has been prepared for running docker."

--- a/infra.yaml
+++ b/infra.yaml
@@ -288,6 +288,10 @@ parameters:
       The Openshift Router Virtual IP
     type: string
 
+  volume_quota:
+    type: number
+    description: Quota for emptyDir volumes in GBi
+
 resources:
 
   # A VM to provide host based orchestration and other sub-services
@@ -383,6 +387,8 @@ resources:
           default: {get_resource: host}
         - name: router_vip
           default: {get_param: router_vip}
+        - name: volume_quota
+          default: {get_param: volume_quota}
       outputs:
         - name: ca_cert
         - name: ca_key
@@ -459,6 +465,9 @@ resources:
         - path: /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/masters.yml
           permissions: 0644
           content: {get_file: templates/var/lib/ansible/group_vars/masters.yml}
+        - path: /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/nodes.yml
+          permissions: 0644
+          content: {get_file: templates/var/lib/ansible/group_vars/nodes.yml}
         - path: /var/lib/os-apply-config/templates/var/lib/ansible/host_vars/loadbalancer.yml
           permissions: 0644
           content: {get_file: templates/var/lib/ansible/host_vars/loadbalancer.yml}
@@ -489,6 +498,18 @@ resources:
         - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/ipfailover.yml
           permissions: 0644
           content: {get_file: templates/var/lib/ansible/playbooks/ipfailover.yml}
+        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/quota.yml
+          permissions: 0644
+          content: {get_file: templates/var/lib/ansible/playbooks/quota.yml}
+        - path: /var/lib/os-apply-config/templates/var/lib/ansible/roles/reboot/tasks/main.yml
+          permissions: 0644
+          content: {get_file: templates/var/lib/ansible/roles/reboot/tasks/main.yml}
+        - path: /var/lib/os-apply-config/templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml
+          permissions: 0644
+          content: {get_file: templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml}
+        - path: /var/lib/os-apply-config/templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml
+          permissions: 0644
+          content: {get_file: templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 

--- a/node.yaml
+++ b/node.yaml
@@ -180,6 +180,11 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
+  container_quota:
+    type: number
+    description: Quota for container in GB
+    default: 0
+
 resources:
 
   # Generate a string to distinguish one node from the others
@@ -344,6 +349,7 @@ resources:
             $DNS_IP: {get_param: dns_ip}
             $SKIP_DNS: {get_param: skip_dns}
             $DOCKER_VOLUME_ID: {get_attr: [docker_volume, volume_id]}
+            $CONTAINER_QUOTA: {get_param: container_quota}
           template: {get_file: fragments/node-boot.sh}
 
   # Create a network connection on the fixed network and apply security

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -108,7 +108,6 @@ parameters:
       List of policies applied on master nodes ServerGroup.
     default: ['anti-affinity']
 
-
   node_count:
     type: number
     description: >
@@ -159,7 +158,6 @@ parameters:
       size of a cinder volume in GB to allocate to docker for container/image
       storage
     default: 25
-
 
   # Node scaling parameters
   autoscaling:
@@ -327,6 +325,12 @@ parameters:
     description: If the registry volume should be formatted during deployment.
     default: false
 
+  volume_quota:
+    type: number
+    description: Quota for emptyDir volumes in GB
+    default: 0
+
+
 resources:
 
   # Network Components
@@ -433,6 +437,7 @@ resources:
             '%stackname%': {get_param: 'OS::stack_name'}
             '%hostname%': {get_param: lb_hostname}
       router_vip: {get_attr: [ipfailover, router_vip]}
+      volume_quota: {get_param: volume_quota}
 
   openshift_masters:
     depends_on: external_router_interface

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -330,6 +330,10 @@ parameters:
     description: Quota for emptyDir volumes in GB
     default: 0
 
+  container_quota:
+    type: number
+    description: Quota for container in GB
+    default: 0
 
 resources:
 
@@ -533,6 +537,7 @@ resources:
             list_join:
               - " "
               - {get_attr: [openshift_masters, hostname]}
+          container_quota: {get_param: container_quota}
 
   # Define the network access policy for openshift nodes
   node_security_group:

--- a/templates/var/lib/ansible/group_vars/nodes.yml
+++ b/templates/var/lib/ansible/group_vars/nodes.yml
@@ -1,0 +1,3 @@
+{{#volume_quota}}
+openshift_node_local_quota_per_fsgroup: {{ volume_quota }}Gi
+{{/volume_quota}}

--- a/templates/var/lib/ansible/playbooks/main.yml
+++ b/templates/var/lib/ansible/playbooks/main.yml
@@ -2,11 +2,16 @@
 <%^skip_dns%>
 - include: /var/lib/ansible/playbooks/dns.yml
 <%/skip_dns%>
+<%#ansible_first_run%>
 <%#deploy_registry%>
 <%#prepare_registry%>
 - include: /var/lib/ansible/playbooks/registry.yml
 <%/prepare_registry%>
 <%/deploy_registry%>
+<%#volume_quota%>
+- include: /var/lib/ansible/playbooks/quota.yml
+<%/volume_quota%>
+<%/ansible_first_run%>
 
 - include: /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
   vars:

--- a/templates/var/lib/ansible/playbooks/quota.yml
+++ b/templates/var/lib/ansible/playbooks/quota.yml
@@ -1,0 +1,9 @@
+---
+- name: Apply gquota options to XFS mount points
+  hosts: masters, nodes
+  roles:
+    - role: fstab_mount_options
+      fmo_mount_point: "/"
+      fmo_mount_options: "gquota"
+    - role: xfs_grub_quota
+    - role: reboot

--- a/templates/var/lib/ansible/playbooks/registry.yml
+++ b/templates/var/lib/ansible/playbooks/registry.yml
@@ -7,13 +7,11 @@
     command: mktemp -d /tmp/registry-volume-XXXXXXX
     register: mktemp
     changed_when: False
-    when: ansible_first_run | default(false) | bool
 
   - name: Check if Openstack clients are installed
     command: rpm -q python-novaclient python-cinderclient python-keystoneclient
     register: rpm_check
     ignore_errors: true
-    when: ansible_first_run | default(false) | bool
 
   - name: Setup RDO repositories
     yum: name=https://rdoproject.org/repos/rdo-release.rpm state=present
@@ -21,40 +19,31 @@
 
   - name: Install Nova and Cinder clients
     yum: name=python-novaclient,python-cinderclient,python-keystoneclient state=latest
-    when: ansible_first_run | default(false) | bool
 
   - name: Attach the volume to the VM
     shell: nova --os-auth-url {{ openshift_cloudprovider_openstack_auth_url }} --os-username {{ openshift_cloudprovider_openstack_username }} --os-password {{ openshift_cloudprovider_openstack_password }} --os-tenant-name {{ openshift_cloudprovider_openstack_tenant_name }} volume-attach {{ infra_instance_id }} {{ openshift_hosted_registry_storage_openstack_volumeID }}
-    when: ansible_first_run | default(false) | bool
 
   - name: Wait for the device to appear
     wait_for: path=/dev/vdc
-    when: ansible_first_run | default(false) | bool
 
   - name: Format the device
     filesystem: fstype={{ openshift_hosted_registry_storage_openstack_filesystem }} dev=/dev/vdc
-    when: ansible_first_run | default(false) | bool
 
   - name: Mount the device
     mount: name={{ mktemp.stdout }} src=/dev/vdc state=mounted fstype={{ openshift_hosted_registry_storage_openstack_filesystem }}
-    when: ansible_first_run | default(false) | bool
 
   - name: Change mode on the filesystem
     file: path={{ mktemp.stdout }} state=directory recurse=true mode=0777
-    when: ansible_first_run | default(false) | bool
 
   - name: Unmount the device
     mount: name={{ mktemp.stdout }} src=/dev/vdc state=unmounted fstype={{ openshift_hosted_registry_storage_openstack_filesystem }}
-    when: ansible_first_run | default(false) | bool
 
   - name: Delete temp directory
     file:
       name: "{{ mktemp.stdout }}"
       state: absent
     changed_when: False
-    when: ansible_first_run | default(false) | bool
 
   - name: Detach the volume to the VM
     shell: nova --os-auth-url {{ openshift_cloudprovider_openstack_auth_url }} --os-username {{ openshift_cloudprovider_openstack_username }} --os-password {{ openshift_cloudprovider_openstack_password }} --os-tenant-name {{ openshift_cloudprovider_openstack_tenant_name }} volume-detach {{ infra_instance_id }} {{ openshift_hosted_registry_storage_openstack_volumeID }}
-    when: ansible_first_run | default(false) | bool
 <%={{ }}=%>

--- a/templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml
+++ b/templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml
@@ -1,0 +1,35 @@
+{{=<% %>=}}
+---
+- name: grab mount point line from fstab
+  shell: /usr/bin/awk '($1 !~ /^#/) && ($2=="{{ fmo_mount_point }}")' /etc/fstab
+  register: fstab_line
+  changed_when: False
+
+- debug: var=fstab_line
+
+- name: fail when
+  fail:
+    msg: Didn't find just one fstab line
+  when: fstab_line.stdout_lines | length != 1
+
+- name: set var facts
+  set_fact:
+    mount_opts: |
+      {% set rval = fstab_line.stdout.strip().split() %}
+      {{- rval -}}
+
+- name: debug
+  debug:
+    var: mount_opts
+
+- name: update mount point with mount options in fstab
+  mount:
+    state: present
+    fstab: /etc/fstab
+    src: "{{ mount_opts[0] }}"
+    name: "{{ mount_opts[1] }}"
+    fstype: "{{ mount_opts[2] }}"
+    opts: "{{ fmo_mount_options }}"
+    dump: "{{ mount_opts[4] }}"
+    passno: "{{ mount_opts[5] }}"
+<%={{ }}=%>

--- a/templates/var/lib/ansible/roles/reboot/tasks/main.yml
+++ b/templates/var/lib/ansible/roles/reboot/tasks/main.yml
@@ -1,0 +1,15 @@
+{{=<% %>=}}
+---
+- name: Reboot server
+  command: /usr/bin/systemd-run --on-active=5 /usr/bin/systemctl reboot
+  async: 0
+  poll: 0
+
+- name: Wait for the server to reboot
+  sudo: no
+  local_action: wait_for host="{{ inventory_hostname }}" search_regex=OpenSSH port=22 timeout=300 state=stopped
+
+- name: Wait for the server to finish rebooting
+  sudo: no
+  local_action: wait_for host="{{ inventory_hostname }}" search_regex=OpenSSH port=22 timeout=300 state=started
+<%={{ }}=%>

--- a/templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml
+++ b/templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml
@@ -1,0 +1,8 @@
+{{=<% %>=}}
+---
+- name: update kernel command line to add gquota
+  shell: grep rootflags=gquota /etc/default/grub || sed -i 's/\(GRUB_CMDLINE_LINUX="\)\(.*\)"/\1rootflags=gquota \2"/' /etc/default/grub
+
+- name: regenerate grub configuration
+  shell: /sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+<%={{ }}=%>


### PR DESCRIPTION
This PR adds support for quota on emptyDir volumes. For this to work,
the filesystem that hosts /var must be of type XFS. In our case, it is the root
filesystem. To enable group quotas on the root filesystem, we need to modify
the GRUB configuration and reboot the machine. To enable this feature,
the parameter 'volume_quota' must be set to a value in GB.

Also part of this PR is a patch that allows setting a maximum size for a
container disk with the use of a new parameter 'container_quota' (size in GB)
