### PR TITLE
Revert "Fix wrong ansible config file path"

### DIFF
--- a/fragments/tune-ansible.sh
+++ b/fragments/tune-ansible.sh
@@ -9,7 +9,7 @@ set -eux
 # Return the last non-zero exit code from a pipe (or zero for success)
 set -o pipefail
 
-ANSIBLE_CFG=/etc/ansible/ansible.cfg
+ANSIBLE_CFG=/etc/ansible_ansible.cfg
 
 # Make a single change to the local Ansible configuration file
 function set_ansible_configuration() {


### PR DESCRIPTION
The tune ansible script is broken by itself and
it breaks ansible.cfg file. Needs more investigation before
merging this.

This reverts commit 787137fbc5ad13da0bb455064dbe2969608d7fd7.
