### PR TITLE
Unregister nodes when deleting them

### DIFF
--- a/fragments/infra-node-cleanup.sh
+++ b/fragments/infra-node-cleanup.sh
@@ -13,6 +13,27 @@ set -eux
 # MAIN
 # ============================================================================
 
+# used by ansible for setting ControlPath ssh param
+export HOME=/root
+
+# remove the node from the openshift service using the first master
+INVENTORY=/var/lib/ansible/inventory
+[ -e $INVENTORY -a "$node_type" == node ] && ansible masters[0] -m shell \
+        -u $ssh_user --sudo -i $INVENTORY \
+        -a "oc --config ~/.kube/config delete node $node_name" || true
+
+# remove from the local list
+NODESFILE=/var/lib/ansible/${node_type}_list
+if [ -e $NODESFILE ]; then
+    cp $NODESFILE{,.bkp}
+    grep -v "$node_name" ${NODESFILE}.bkp > $NODESFILE || true
+fi
+
+# unregister the node if registered with subscription-manager
+[ -e $INVENTORY ] && ansible $node_name -m shell \
+        -u $ssh_user --sudo -i $INVENTORY \
+        -a "subscription-manager unregister && subscription-manager clean" || true
+
 # If Local DNS is disabled, make no changes
 [ "$SKIP_DNS" = "true" ] && exit 0
 
@@ -22,21 +43,5 @@ cp /etc/hosts{,.bkp}
 # Remove the node IP entry from the hosts file (saving the backup)
 grep -v "$node_name" /etc/hosts.bkp > /etc/hosts
 [ -e /run/ostree-booted ] && cp /etc/hosts /host/etc/hosts
-
-# used by ansible for setting ControlPath ssh param
-export HOME=/root
-
-# remove the node from the openshift service using the first master
-INVENTORY=/var/lib/ansible/inventory
-[ -e $INVENTORY ] && ansible masters[0] -m shell \
-        -u $ssh_user --sudo -i $INVENTORY \
-        -a "oc --config ~/.kube/config delete node $node_name" || true
-
-# remove from the local list
-NODESFILE=/var/lib/ansible/node_list
-if [ -e $NODESFILE ]; then
-    cp $NODESFILE{,.bkp}
-    grep -v "$node_name" ${NODESFILE}.bkp > $NODESFILE || true
-fi
 
 echo "Deleted node $node_name"

--- a/infra.yaml
+++ b/infra.yaml
@@ -579,13 +579,13 @@ resources:
             $SKIP_DNS: {get_param: skip_dns}
           template: {get_file: fragments/infra-node-add.sh}
 
-  # Remove a node's IP/Name mapping from DNS
   node_cleanup:
     type: OS::Heat::SoftwareConfig
     properties:
       group: script
       inputs:
       - name: node_name
+      - name: node_type
       - name: ssh_user
         default: {get_param: ssh_user}
       outputs:
@@ -595,6 +595,26 @@ resources:
           params:
             $SKIP_DNS: {get_param: skip_dns}
           template: {get_file: fragments/infra-node-cleanup.sh}
+
+  # activation hook for removing the node from DNS and from the Kubernetes
+  # cluster
+  deployment_infra_node_cleanup:
+    depends_on: host
+    type: OS::Heat::SoftwareDeployment
+    properties:
+      actions: ['DELETE']
+      input_values:
+        node_type: infra
+        node_name:
+          str_replace:
+            template: "HOST.DOMAIN"
+            params:
+              HOST: {get_param: hostname}
+              DOMAIN: {get_param: domain_name}
+      config:
+        get_resource: node_cleanup
+      server:
+        get_resource: host
 
   # Additional space for Docker container and image storage
   docker_volume:

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -124,6 +124,12 @@ parameters:
     type: number
     default: 4000
 
+  infra_node:
+    type: string
+    description: >
+      The name or ID of an infrastructure instance.
+    default: ''
+
 resources:
   floating_ip_assoc:
     type: OS::Neutron::FloatingIPAssociation
@@ -282,6 +288,43 @@ resources:
           params:
             $DNS_IP: {get_param: dns_ip}
           template: {get_file: fragments/lb-boot.sh}
+
+  node_cleanup:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      inputs:
+      - name: node_name
+      - name: node_type
+      - name: ssh_user
+        default: {get_param: ssh_user}
+      outputs:
+      - name: result
+      config:
+        str_replace:
+          params:
+            $SKIP_DNS: {get_param: skip_dns}
+          template: {get_file: fragments/infra-node-cleanup.sh}
+
+  # activation hook for removing the node from DNS and from the Kubernetes
+  # cluster
+  deployment_infra_node_cleanup:
+    depends_on: host
+    type: OS::Heat::SoftwareDeployment
+    properties:
+      actions: ['DELETE']
+      input_values:
+        node_type: loadbalancer
+        node_name:
+          str_replace:
+            template: "HOST.DOMAIN"
+            params:
+              HOST: {get_param: hostname}
+              DOMAIN: {get_param: domain_name}
+      config:
+        get_param: node_cleanup
+      server:
+        get_param: infra_node
 
   # Wait for the load balancer host to complete cloud-init or time out
   wait_condition:

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -122,6 +122,12 @@ parameters:
     type: string
     default: ''
 
+  infra_node:
+    type: string
+    description: >
+      The name or ID of an infrastructure instance.
+    default: ''
+
 outputs:
   console_url:
     description: URL of the OpenShift web console

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -115,6 +115,12 @@ parameters:
     type: string
     default: ''
 
+  infra_node:
+    type: string
+    description: >
+      The name or ID of an infrastructure instance.
+    default: ''
+
 resources:
   lb:
     type: OS::Neutron::LoadBalancer

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -121,6 +121,12 @@ parameters:
     type: string
     default: ''
 
+  infra_node:
+    type: string
+    description: >
+      The name or ID of an infrastructure instance.
+    default: ''
+
 outputs:
   console_url:
     description: URL of the OpenShift web console

--- a/master.yaml
+++ b/master.yaml
@@ -236,6 +236,23 @@ parameters:
 
 resources:
 
+  node_cleanup:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      inputs:
+      - name: node_name
+      - name: node_type
+      - name: ssh_user
+        default: {get_param: ssh_user}
+      outputs:
+      - name: result
+      config:
+        str_replace:
+          params:
+            $SKIP_DNS: {get_param: skip_dns}
+          template: {get_file: fragments/infra-node-cleanup.sh}
+
   # Create a network connection on the internal communications network
   port:
     type: OS::Neutron::Port
@@ -438,6 +455,26 @@ resources:
                 IP: {get_attr: [host, networks, {get_param: fixed_network}, 0]}
                 HOST: {get_param: hostname}
                 DOMAIN: {get_param: domain_name}
+
+  # activation hook for removing the node from DNS and from the Kubernetes
+  # cluster
+  deployment_infra_node_cleanup:
+    depends_on: host
+    type: OS::Heat::SoftwareDeployment
+    properties:
+      actions: ['DELETE']
+      input_values:
+        node_type: master
+        node_name:
+          str_replace:
+            template: "HOST.DOMAIN"
+            params:
+              HOST: {get_param: hostname}
+              DOMAIN: {get_param: domain_name}
+      config:
+        get_resource: node_cleanup
+      server:
+        get_param: infra_node
 
   # Wait for master_boot (cloud-init) to complete or time out
   wait_condition:

--- a/node.yaml
+++ b/node.yaml
@@ -148,12 +148,6 @@ parameters:
     type: string
     default: ''
 
-  infra_node_cleanup:
-    description: >
-      Operation that removes the node from the infrastructure DNS
-    type: string
-    default: ''
-
   timeout:
     description: Time to wait until the node is ready.
     type: number
@@ -365,22 +359,24 @@ resources:
       network: {get_param: internal_network}
       subnet: {get_param: internal_subnet}
 
+  node_cleanup:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      config: |
+        #!/bin/bash
+        set -eux
+        (subscription-manager unregister && subscription-manager clean) || true
+
   # activation hook for removing the node from DNS and from the Kubernetes
   # cluster
   deployment_infra_node_cleanup:
+    depends_on: host
     type: OS::Heat::SoftwareDeployment
     properties:
       actions: ['DELETE']
-      input_values:
-        node_name:
-          str_replace:
-            template: "HOST-SUFFIX.DOMAIN"
-            params:
-              HOST: {get_param: hostname}
-              SUFFIX: {get_attr: [random_hostname_suffix, value]}
-              DOMAIN: {get_param: domain_name}
       config:
-        get_param: infra_node_cleanup
+        get_resource: node_cleanup
       server:
         get_param: infra_node
 

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -516,8 +516,6 @@ resources:
           ansible_public_key: {get_attr: [ansible_keys, public_key]}
           infra_node: {get_attr: [infra_host, resource.host]}
           infra_run_ansible: {get_attr: [infra_host, resource.run_ansible]}
-          infra_node: {get_attr: [infra_host, resource.host]}
-          infra_node_cleanup: {get_attr: [infra_host, resource.node_cleanup]}
           infra_node_add: {get_attr: [infra_host, resource.node_add]}
           skip_dns: {get_param: skip_dns}
           system_update: {get_param: system_update}
@@ -745,6 +743,7 @@ resources:
       extra_repository_urls: {get_param: extra_repository_urls}
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
       stack_name: {get_param: 'OS::stack_name'}
+      infra_node: {get_attr: [infra_host, resource.host]}
 
 outputs:
   dns_ip:


### PR DESCRIPTION
SoftwareConfig is moved into nested templates because heat
doesn't support dependency between resources when passed as
parameters into nested templates.
