### PR TITLE
add subscription manager register to satellite

### DIFF
--- a/env_aop.yaml
+++ b/env_aop.yaml
@@ -7,9 +7,14 @@ parameters:
   external_network: ext_net
   dns_nameserver: 8.8.4.4,8.8.8.8
   node_count: 2
+
   rhn_username: "Your RHN Username"
   rhn_password: "Your RHN Password"
+  sat6_hostname: ""
+  sat6_organization: ""
+  sat6_activationkey: ""
   rhn_pool: ''
+
   deployment_type: openshift-enterprise
   domain_name: "example.com"
   master_hostname: "openshift-master"

--- a/env_origin.yaml
+++ b/env_origin.yaml
@@ -7,9 +7,14 @@ parameters:
   external_network: ext_net
   dns_nameserver: 8.8.4.4,8.8.8.8
   node_count: 2
+
   rhn_username: ""
   rhn_password: ""
+  sat6_hostname: ""
+  sat6_organization: ""
+  sat6_activationkey: ""
   rhn_pool: ''
+
   deployment_type: origin
   domain_name: "example.com"
   master_hostname: "origin-master"

--- a/fragments/rhn-register.sh
+++ b/fragments/rhn-register.sh
@@ -7,6 +7,12 @@
 #   RHN_PASSWORD - password for the RHN user
 #   POOL_ID - OPTIONAL - a specific pool with OpenShift entitlements
 #   EXTRA_POOL_IDS - OPTIONAL - additional pools
+#   SAT6_HOSTNAME - The hostname of the Sat6 server to register to
+#   SAT6_ORGANIZAION - An Organization string to aid grouping of hosts
+#   SAT6_ACTIVATIONKEY - A string used to authorize the registration
+#
+#   OSE_VERSION - the version of the OS repo to enable
+OSE_VERSION=${OSE_VERSION:-"3.2"}
 
 # Exit on command fail
 set -eu
@@ -15,17 +21,49 @@ set -x
 # Return the final non-zero exit code of a failed pipe (or 0 for success)
 set -o pipefail
 
+function use_satellite6() {
+    [ -n "$SAT6_HOSTNAME" ]
+}
+
+function use_rhn() {
+    [ -n "$RHN_USERNAME" -a -n "$RHN_PASSWORD" ]
+}
+
+function register_rhn() {
+    # RHN_USERNAME=$1
+    # RHN_PASSWORD=$2
+    retry subscription-manager register --username="$1" --password="$2"
+}
+
+function install_sat6_ca_certs() {
+    # SAT6_HOSTNAME=$1
+    local SAT6_KEY_RPM="katello-ca-consumer-$1"
+    local SAT6_KEY_RPM_URL="$https://${1}/pub/katello-ca-consumer-latest.noarch.rpm"
+
+    if ! rpm -q --quiet $SAT6_KEY_RPM ; then
+        yum -y install $SAT6_KEY_RPM_URL
+    fi
+}
+
+function register_sat6() {
+    # SAT6_ORGANIZATION=$1
+    # SAT6_ACTIVATIONKEY=$2
+    # register as a sat6 client
+    retry subscription-manager register --org="$1" --activationkey="$1"
+}
+
 # =============================================================================
 # MAIN
 # =============================================================================
 
-# Do nothin if either username or password is missing
-[ -n "$RHN_USERNAME" -a -n "$RHN_PASSWORD" ] || exit 0
-
-# Register this host with RHN
-retry subscription-manager register \
-      --username="$RHN_USERNAME" \
-      --password="$RHN_PASSWORD"
+if use_satellite6 ; then
+    install_sat6_ca_certs $SAT6_HOSTNAME
+    register_sat6 $SAT6_ORGANIZATION $SAT6_ACTIVATIONKEY
+elif use_rhn ; then
+    register_rhn $RHN_USERNAME $RHN_PASSWORD
+else
+    exit 0
+fi
 
 # Attach to an entitlement pool
 if [ -n "$POOL_ID" ]; then
@@ -44,7 +82,7 @@ subscription-manager repos \
                      --enable="rhel-7-server-rpms" \
                      --enable="rhel-7-server-extras-rpms" \
                      --enable="rhel-7-server-optional-rpms" \
-                     --enable="rhel-7-server-ose-3.2-rpms"
+                     --enable="rhel-7-server-ose-$OSE_VERSION-rpms"
 
 # Allow RPM integrity checking
 rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/infra.yaml
+++ b/infra.yaml
@@ -7,6 +7,13 @@ description: >
 
 parameters:
 
+  # What version of OpenShift Enterprise to install
+  # This value is used to select the RPM repo for the OSE release to install
+  ose_version:
+    type: string
+    description: >
+      The version of OpenShift Enterprise to deploy
+
   key_name:
     description: >
       A pre-submitted SSH key to access the VM hosts
@@ -49,6 +56,25 @@ parameters:
       The password for the RHN user
     type: string
     hidden: true
+
+  # Red Hat satellite subscription parameters
+  sat6_hostname:
+    type: string
+    description: >
+      The hostname of the Satellite 6 server which will provide software updates
+    default: ''
+
+  sat6_organization:
+    type: string
+    description: >
+      An organization string provided by Sat6 to group subscriptions
+    default: ''
+
+  sat6_activationkey:
+    type: string
+    description: >
+      An activation key string provided by Sat6 to enable subscriptions
+    default: ''
 
   rhn_pool:
     description: >
@@ -524,9 +550,13 @@ resources:
       config:
         str_replace:
           params:
+            $OSE_VERSION: {get_param: ose_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
-            $POOL_ID: {get_param: rhn_pool} 
+            $SAT6_HOSTNAME: {get_param: sat6_hostname}
+            $SAT6_ORGANIZATION: {get_param: sat6_organization}
+            $SAT6_ACTIVATIONKEY: {get_param: sat6_activationkey}
+            $POOL_ID: {get_param: rhn_pool}
             $EXTRA_POOL_IDS: 
               list_join:
                 - " --pool="

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -5,6 +5,13 @@ description: >
 
 parameters:
 
+  # What version of OpenShift Enterprise to install
+  # This value is used to select the RPM repo for the OSE release to install
+  ose_version:
+    type: string
+    description: >
+      The version of OpenShift Enterprise to deploy
+
   key_name:
     description: >
       A pre-submitted SSH key to access the VM hosts
@@ -46,6 +53,24 @@ parameters:
       The password for the RHN user
     type: string
     hidden: true
+
+  # Red Hat satellite subscription parameters
+  sat6_hostname:
+    type: string
+    description: >
+      The hostname of the Satellite 6 server which will provide software updates
+    default: ''
+
+  sat6_organization:
+    type: string
+    description: >
+      An organization string provided by Sat6 to group subscriptions
+    default: ''
+
+  sat6_activationkey:
+    type: string
+    description: >
+      An activation key string provided by Sat6 to enable subscriptions
 
   rhn_pool:
     description: >
@@ -238,8 +263,12 @@ resources:
       config:
         str_replace:
           params:
+            $OSE_VERSION: {get_param: ose_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
+            $SAT6_HOSTNAME: {get_param: sat6_ hostname}
+            $SAT6_ORGANIZATION: {get_param: sat6_organization}
+            $SAT6_ACTIVATIONKEY: {get_param: sat6_activationkey}
             $POOL_ID: {get_param: rhn_pool}
             $EXTRA_POOL_IDS:
               list_join:

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -6,6 +6,13 @@ description: >
 
 parameters:
 
+  # What version of OpenShift Enterprise to install
+  # This value is used to select the RPM repo for the OSE release to install
+  ose_version:
+    type: string
+    description: >
+      The version of OpenShift Enterprise to deploy
+
   key_name:
     description: >
       A pre-submitted SSH key to access the VM hosts
@@ -44,6 +51,24 @@ parameters:
       The password for the RHN user
     type: string
     hidden: true
+
+# Red Hat satellite subscription parameters
+  sat6_hostname:
+    type: string
+    description: >
+      The hostname of the Satellite 6 server which will provide software updates
+    default: ''
+
+  sat6_organization:
+    type: string
+    description: >
+      An organization string provided by Sat6 to group subscriptions
+    default: ''
+
+  sat6_activationkey:
+    type: string
+    description: >
+      An activation key string provided by Sat6 to enable subscriptions
 
   rhn_pool:
     description: >

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -5,6 +5,13 @@ description: >
 
 parameters:
 
+  # What version of OpenShift Enterprise to install
+  # This value is used to select the RPM repo for the OSE release to install
+  ose_version:
+    type: string
+    description: >
+      The version of OpenShift Enterprise to deploy
+
   key_name:
     description: >
       A pre-submitted SSH key to access the VM hosts
@@ -43,6 +50,24 @@ parameters:
       The password for the RHN user
     type: string
     hidden: true
+
+  # Red Hat satellite subscription parameters
+  sat6_hostname:
+    type: string
+    description: >
+      The hostname of the Satellite 6 server which will provide software updates
+    default: ''
+
+  sat6_organization:
+    type: string
+    description: >
+      An organization string provided by Sat6 to group subscriptions
+    default: ''
+
+  sat6_activationkey:
+    type: string
+    description: >
+      An activation key string provided by Sat6 to enable subscriptions
 
   rhn_pool:
     description: >

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -5,6 +5,13 @@ description: >
 
 parameters:
 
+  # What version of OpenShift Enterprise to install
+  # This value is used to select the RPM repo for the OSE release to install
+  ose_version:
+    type: string
+    description: >
+      The version of OpenShift Enterprise to deploy
+
   key_name:
     description: >
       A pre-submitted SSH key to access the VM hosts
@@ -43,6 +50,24 @@ parameters:
       The password for the RHN user
     type: string
     hidden: true
+
+  # Red Hat satellite subscription parameters
+  sat6_hostname:
+    type: string
+    description: >
+      The hostname of the Satellite 6 server which will provide software updates
+    default: ''
+
+  sat6_organization:
+    type: string
+    description: >
+      An organization string provided by Sat6 to group subscriptions
+    default: ''
+
+  sat6_activationkey:
+    type: string
+    description: >
+      An activation key string provided by Sat6 to enable subscriptions
 
   rhn_pool:
     description: >

--- a/master.yaml
+++ b/master.yaml
@@ -7,6 +7,13 @@ description: >
 
 parameters:
 
+  # What version of OpenShift Enterprise to install
+  # This value is used to select the RPM repo for the OSE release to install
+  ose_version:
+    type: string
+    description: >
+      The version of OpenShift Enterprise to deploy
+
   key_name:
     description: >
       A pre-submitted SSH key to access the VM hosts
@@ -49,6 +56,25 @@ parameters:
       The password for the RHN user
     type: string
     hidden: true
+
+  # Red Hat satellite subscription parameters
+  sat6_hostname:
+    type: string
+    description: >
+      The hostname of the Satellite 6 server which will provide software updates
+    default: ''
+
+  sat6_organization:
+    type: string
+    description: >
+      An organization string provided by Sat6 to group subscriptions
+    default: ''
+
+  sat6_activationkey:
+    type: string
+    description: >
+      An activation key string provided by Sat6 to enable subscriptions
+    default: ''
 
   rhn_pool:
     description: >
@@ -365,8 +391,12 @@ resources:
       config:
         str_replace:
           params:
+            $OSE_VERSION: {get_param: ose_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
+            $SAT6_HOSTNAME: {get_param: sat6_hostname}
+            $SAT6_ORGANIZATION: {get_param: sat6_organization}
+            $SAT6_ACTIVATIONKEY: {get_param: sat6_activationkey}
             $POOL_ID: {get_param: rhn_pool}
             $EXTRA_POOL_IDS:
               list_join:

--- a/node.yaml
+++ b/node.yaml
@@ -7,6 +7,13 @@ description: >
 
 parameters:
 
+  # What version of OpenShift Enterprise to install
+  # This value is used to select the RPM repo for the OSE release to install
+  ose_version:
+    type: string
+    description: >
+      The version of OpenShift Enterprise to deploy
+
   key_name:
     description: >
       A pre-submitted SSH key to access the VM hosts
@@ -83,6 +90,24 @@ parameters:
     type: string
     hidden: true
   
+  # Red Hat satellite subscription parameters
+  sat6_hostname:
+    type: string
+    description: >
+      The hostname of the Satellite 6 server which will provide software updates
+    default: ''
+
+  sat6_organization:
+    type: string
+    description: >
+      An organization string provided by Sat6 to group subscriptions
+    default: ''
+
+  sat6_activationkey:
+    type: string
+    description: >
+      An activation key string provided by Sat6 to enable subscriptions
+
   rhn_pool:
     description: >
       A subscription pool containing the RHEL and OpenShift software repos
@@ -289,8 +314,12 @@ resources:
       config:
         str_replace:
           params:
+            $OSE_VERSION: {get_param: ose_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
+            $SAT6_HOSTNAME: {get_param: sat6_hostname}
+            $SAT6_ORGANIZATION: {get_param: sat6_organization}
+            $SAT6_ACTIVATIONKEY: {get_param: sat6_activationkey}
             $POOL_ID: {get_param: rhn_pool}
             $EXTRA_POOL_IDS:
               list_join:

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -7,6 +7,14 @@ description: >
 
 parameters:
 
+  # What version of OpenShift Enterprise to install
+  # This value is used to select the RPM repo for the OSE release to install
+  ose_version:
+    type: string
+    default: "3.2"
+    description: >
+      The version of OpenShift Enterprise to deploy
+
   # Access to the VMs
   ssh_user:
     type: string
@@ -266,6 +274,25 @@ parameters:
     hidden: true
     default: ''
 
+  # Red Hat satellite subscription parameters
+  sat6_hostname:
+    type: string
+    description: >
+      The hostname of the Satellite 6 server which will provide software updates
+    default: ''
+
+  sat6_organization:
+    type: string
+    description: >
+      An organization string provided by Sat6 to group subscriptions
+    default: ''
+
+  sat6_activationkey:
+    type: string
+    description: >
+      An activation key string provided by Sat6 to enable subscriptions
+    default: ''
+
   rhn_pool:
     type: string
     description: >
@@ -390,12 +417,16 @@ resources:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
     type: infra.yaml
     properties:
+      ose_version: {get_param: ose_version}
       image: {get_param: infra_image}
       flavor: {get_param: flavor}
       key_name: {get_param: ssh_key_name}
       ssh_user: {get_param: ssh_user}
       rhn_username: {get_param: rhn_username}
       rhn_password: {get_param: rhn_password}
+      sat6_hostname: {get_param: sat6_hostname}
+      sat6_organization: {get_param: sat6_organization}
+      sat6_activationkey: {get_param: sat6_activationkey}
       rhn_pool: {get_param: rhn_pool}
       extra_rhn_pools: {get_param: extra_rhn_pools}
       hostname:
@@ -451,6 +482,7 @@ resources:
       resource_def:
         type: master.yaml
         properties:
+          ose_version: {get_param: ose_version}
           image: {get_param: master_image}
           flavor: {get_param: flavor}
           key_name: {get_param: ssh_key_name}
@@ -458,6 +490,9 @@ resources:
           dns_ip: {get_attr: [infra_host, instance_ip]}
           rhn_username: {get_param: rhn_username}
           rhn_password: {get_param: rhn_password}
+          sat6_hostname: {get_param: sat6_hostname}
+          sat6_organization: {get_param: sat6_organization}
+          sat6_activationkey: {get_param: sat6_activationkey}
           rhn_pool: {get_param: rhn_pool}
           extra_rhn_pools: {get_param: extra_rhn_pools}
           deployment_type: {get_param: deployment_type}
@@ -500,6 +535,7 @@ resources:
       resource:
         type: node.yaml
         properties:
+          ose_version: {get_param: ose_version}
           image: {get_param: node_image}
           flavor: {get_param: flavor}
           key_name: {get_param: ssh_key_name}
@@ -513,6 +549,9 @@ resources:
           docker_volume_size: {get_param: node_docker_volume_size_gb}
           rhn_username: {get_param: rhn_username}
           rhn_password: {get_param: rhn_password}
+          sat6_hostname: {get_param: sat6_hostname}
+          sat6_organization: {get_param: sat6_organization}
+          sat6_activationkey: {get_param: sat6_activationkey}
           rhn_pool: {get_param: rhn_pool}
           extra_rhn_pools: {get_param: extra_rhn_pools}
           hostname:
@@ -732,12 +771,16 @@ resources:
   loadbalancer:
     type:  OOShift::LoadBalancer
     properties:
+      ose_version: {get_param: ose_version}
       image: {get_param: loadbalancer_image}
       flavor: {get_param: flavor}
       key_name: {get_param: ssh_key_name}
       ssh_user: {get_param: ssh_user}
       rhn_username: {get_param: rhn_username}
       rhn_password: {get_param: rhn_password}
+      sat6_hostname: {get_param: sat6_hostname}
+      sat6_organization: {get_param: sat6_organization}
+      sat6_activationkey: {get_param: sat6_activationkey}
       rhn_pool: {get_param: rhn_pool}
       extra_rhn_pools: {get_param: extra_rhn_pools}
       hostname: {get_param: lb_hostname}


### PR DESCRIPTION
This change adds three input parameters to the stack:
- `sat6_hostname`
- `sat6_organization`
- `sat6_activationkey`

These parameters are alternates for the `rhn_username` and `rhn_password` parameters.

When the `sat6_*` parameters are provided, each VM will register with a Satellite 6 server for software installation and updates.  The Satellite 6 server must be configured to provide the standard required repos.

https://trello.com/c/2ZYNeUDh/253-add-input-variables-to-heat-stack-allow-subscription-on-satellite-epic-ose-osp-int
