### PR TITLE
Fix host network reference

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -424,6 +424,7 @@ resources:
 
   # Add the hostname and address of the infrastructure host to the master host
   deployment_infra_node_add:
+    depends_on: host
     type: OS::Heat::SoftwareDeployment
     properties:
       config:
@@ -435,7 +436,7 @@ resources:
           str_replace:
               template: "IP HOST.DOMAIN HOST #openshift"
               params:
-                IP: {get_attr: [host, networks, {get_param: fixed_network}, 0]}
+                IP: {get_attr: [port, fixed_ips, 0, ip_address]}
                 HOST: {get_param: hostname}
                 DOMAIN: {get_param: domain_name}
 

--- a/node.yaml
+++ b/node.yaml
@@ -405,6 +405,7 @@ resources:
 
   # activation hook to add the node to DNS and Kubernetes cluster
   deployment_infra_node_add:
+    depends_on: host
     type: OS::Heat::SoftwareDeployment
     properties:
       config:
@@ -424,7 +425,7 @@ resources:
           str_replace:
               template: "IP HOST-SUFFIX.DOMAIN HOST-SUFFIX #openshift"
               params:
-                IP: {get_attr: [host, networks, {get_param: fixed_network}, 0]}
+                IP: {get_attr: [port, fixed_ips, 0, ip_address]}
                 HOST: {get_param: hostname}
                 SUFFIX: {get_attr: [random_hostname_suffix, value]}
                 DOMAIN: {get_param: domain_name}

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -387,7 +387,7 @@ resources:
 
   # VM Host definitions
   infra_host:
-    depends_on: external_router_interface
+    depends_on: [external_router_interface, fixed_network, fixed_subnet]
     type: infra.yaml
     properties:
       image: {get_param: infra_image}
@@ -405,7 +405,7 @@ resources:
             '%stackname%': {get_param: 'OS::stack_name'}
             '%hostname%': {get_param: infra_hostname}
       domain_name: {get_param: domain_name}
-      fixed_network: {get_attr: [fixed_network, name]}
+      fixed_network: {get_resource: fixed_network}
       fixed_subnet: {get_resource: fixed_subnet}
       ansible_public_key: {get_attr: [ansible_keys, public_key]}
       ansible_private_key: {get_attr: [ansible_keys, private_key]}
@@ -444,7 +444,7 @@ resources:
       volume_quota: {get_param: volume_quota}
 
   openshift_masters:
-    depends_on: external_router_interface
+    depends_on: [external_router_interface, fixed_network, fixed_subnet]
     type: OS::Heat::ResourceGroup
     properties:
       count: {get_param: master_count}
@@ -473,7 +473,7 @@ resources:
           ansible_private_key: {get_attr: [ansible_keys, private_key]}
           infra_node: {get_attr: [infra_host, resource.host]}
           infra_node_add: {get_attr: [infra_host, resource.node_add]}
-          fixed_network: {get_attr: [fixed_network, name]}
+          fixed_network: {get_resource: fixed_network}
           fixed_subnet: {get_resource: fixed_subnet}
           internal_network: {get_resource: cluster_network}
           internal_subnet: {get_resource: cluster_subnet}
@@ -491,7 +491,7 @@ resources:
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
 
   openshift_nodes:
-    depends_on: external_router_interface
+    depends_on: [external_router_interface, fixed_network, fixed_subnet]
     type: OS::Heat::AutoScalingGroup
     properties:
       desired_capacity: {get_param: node_count}
@@ -505,7 +505,7 @@ resources:
           key_name: {get_param: ssh_key_name}
           ssh_user: {get_param: ssh_user}
           dns_ip: {get_attr: [infra_host, instance_ip]}
-          fixed_network: {get_attr: [fixed_network, name]}
+          fixed_network: {get_resource: fixed_network}
           fixed_subnet: {get_resource: fixed_subnet}
           internal_network: {get_resource: cluster_network}
           internal_subnet: {get_resource: cluster_subnet}
@@ -748,7 +748,7 @@ resources:
       members: {get_attr: [openshift_masters, host]}
       master_hostname: {get_attr: [openshift_masters, resource.0.hostname]}
       floatingip_id: {get_resource: lb_floating_ip}
-      fixed_network: {get_attr: [fixed_network, name]}
+      fixed_network: {get_resource: fixed_network}
       fixed_subnet: {get_resource: fixed_subnet}
       extra_repository_urls: {get_param: extra_repository_urls}
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}


### PR DESCRIPTION
For some reason referencing host fixed_network's IP doesn't
work as expected in some openstack environments. This
patch uses port resource to obtain the fixed'network IP instead.
Also adds resource dependencies to assure that network&host exist
when the IP is being referenced.

Fixes: #206
