### PR TITLE
Fix resource dependency for SWDeployments

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -424,7 +424,7 @@ resources:
 
   # Add the hostname and address of the infrastructure host to the master host
   deployment_infra_node_add:
-    depends_on: host
+    depends_on: wait_condition
     type: OS::Heat::SoftwareDeployment
     properties:
       config:
@@ -460,7 +460,7 @@ resources:
   # activation hook for removing the node from DNS and from the Kubernetes
   # cluster
   deployment_infra_node_cleanup:
-    depends_on: host
+    depends_on: wait_condition
     type: OS::Heat::SoftwareDeployment
     properties:
       actions: ['DELETE']

--- a/node.yaml
+++ b/node.yaml
@@ -405,7 +405,7 @@ resources:
 
   # activation hook to add the node to DNS and Kubernetes cluster
   deployment_infra_node_add:
-    depends_on: host
+    depends_on: wait_condition
     type: OS::Heat::SoftwareDeployment
     properties:
       config:


### PR DESCRIPTION
Make sure that SWDeployment doesn't run sooner than cloud-init
is finished on a node.

Fixes: #212
