### PR TITLE
Correct node deploy timing issue with ansible

### DIFF
--- a/node.yaml
+++ b/node.yaml
@@ -405,7 +405,7 @@ resources:
 
   # activation hook to add the node to DNS and Kubernetes cluster
   deployment_infra_node_add:
-    depends_on: host
+    depends_on: wait_condition
     type: OS::Heat::SoftwareDeployment
     properties:
       config:


### PR DESCRIPTION
'depends_on: wait_condition' executes ansible playbook main.yaml
with only the truly ready nodes.  Next execution will trigger
ansible playbook scaleup.yaml will any other truly ready nodes.
fixes #212 
