### PR TITLE
Explicitly set replica=1 for registry

### DIFF
--- a/templates/var/lib/ansible/group_vars/OSv3.yml
+++ b/templates/var/lib/ansible/group_vars/OSv3.yml
@@ -51,6 +51,7 @@ openshift_cloudprovider_openstack_password: {{os_password}}
 openshift_cloudprovider_openstack_tenant_name: {{os_tenant_name}}
 openshift_cloudprovider_openstack_region: {{os_region_name}}
 {{#deploy_registry}}
+openshift_hosted_registry_replicas: 1
 openshift_registry_selector: region=infra
 openshift_hosted_registry_storage_create_pv: true
 openshift_hosted_registry_storage_kind: openstack


### PR DESCRIPTION
If unset, openshift-ansible now uses all nodes with selector=infra,
the problem is that when using cinder volume, the same volume would be
mounted to 3 nodes which fails.
