### PR TITLE
Make sure all SW deployments depend on wait_condition

### DIFF
--- a/infra.yaml
+++ b/infra.yaml
@@ -393,6 +393,7 @@ resources:
 
   # Execute the tuning operation on a host
   deployment_tune_ansible:
+    depends_on: wait_condition
     type: OS::Heat::SoftwareDeployment
     properties:
       actions: ['CREATE']
@@ -411,7 +412,7 @@ resources:
         (subscription-manager unregister && subscription-manager clean) || true
 
   deployment_infra_node_cleanup:
-    depends_on: host
+    depends_on: wait_condition
     type: OS::Heat::SoftwareDeployment
     properties:
       actions: ['DELETE']

--- a/node.yaml
+++ b/node.yaml
@@ -532,7 +532,7 @@ resources:
   # activation hook for removing the node from DNS and from the Kubernetes
   # cluster
   deployment_infra_node_cleanup:
-    depends_on: host
+    depends_on: wait_condition
     type: OS::Heat::SoftwareDeployment
     properties:
       actions: ['DELETE']


### PR DESCRIPTION
This also assures that SW deployment resource is not created
until os-collect-config runs on infra node.
