### PR TITLE
Make sure registry volume is not left in /etc/fstab

### DIFF
--- a/templates/var/lib/ansible/playbooks/registry.yml
+++ b/templates/var/lib/ansible/playbooks/registry.yml
@@ -36,7 +36,7 @@
     file: path={{ mktemp.stdout }} state=directory recurse=true mode=0777
 
   - name: Unmount the device
-    mount: name={{ mktemp.stdout }} src=/dev/vdc state=unmounted fstype={{ openshift_hosted_registry_storage_openstack_filesystem }}
+    mount: name={{ mktemp.stdout }} src=/dev/vdc state=absent fstype={{ openshift_hosted_registry_storage_openstack_filesystem }}
 
   - name: Delete temp directory
     file:


### PR DESCRIPTION
Ansible mount module (used for registry volume setup) saves
recs into /etc/fstab. The problem is that this temporary /tmp/registry
is saved there too which causes that infra node ends up in an "emergency"
mode on reboot. Use of "absent" unmounts and removes the volume from
/etc/fstab (albeit ansible doc says it just removes /etc/fstab record).
