### PR TITLE
Refactor skip_dns parameter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -427,10 +427,12 @@ domain used in OpenShift cluster (`example.com` in the example above).
 
 [NOTE]
 ====
-A DNS server is set also on infra node during deployment but this
+A DNS server is set also on bastion node during deployment but this
 server is used only by OpenShift nodes internally and should not be used
 for resolving OpenShift user entry points. We plan to use Designate service
-in near future.
+in near future. Alternatively `skip_dns=true` parameter can be used, then
+instead of DNS server on bastion node openshift-ansible deploys dnsmasq on
+each node.
 ====
 
 == Retrieving the CA certificate

--- a/fragments/bastion-boot.sh
+++ b/fragments/bastion-boot.sh
@@ -7,8 +7,6 @@
 #               used to signal OpenStack of completion status
 #   DNS_IP    - The IP address of the nearest resolver host
 #
-#   SKIP_DNS  - true|false - enable local DNS service updates
-#
 #   OPENSHIFT_ANSIBLE_GIT_URL - the URL of a git repository containing the
 #                               openshift ansible playbooks and configs
 #   OPENSHIFT_ANSIBLE_GIT_REV - the release/revision of the playbooks to use

--- a/fragments/bastion-node-cleanup.sh
+++ b/fragments/bastion-node-cleanup.sh
@@ -38,9 +38,6 @@ fi
         -u $ssh_user --sudo -i $INVENTORY \
         -a "subscription-manager unregister && subscription-manager clean" || true
 
-# If Local DNS is disabled, make no changes
-[ "$SKIP_DNS" = "true" ] && exit 0
-
 # Save a copy of the current host file
 cp /etc/hosts{,.bkp}
 

--- a/fragments/infra-boot.sh
+++ b/fragments/infra-boot.sh
@@ -20,7 +20,7 @@ set -o pipefail
 source /usr/local/share/openshift-on-openstack/common_functions.sh
 source /usr/local/share/openshift-on-openstack/common_openshift_functions.sh
 
-[ "$SKIP_DNS" != "true" ] && add_nameserver $DNS_IP
+[ "$SKIP_DNS" != "True" ] && add_nameserver $DNS_IP
 
 disable_peerdns eth0
 ifup eth1

--- a/fragments/master-ansible.sh
+++ b/fragments/master-ansible.sh
@@ -102,6 +102,14 @@ function is_scaleup() {
         grep '^[<>]' | grep -v '^< .*-node') && return 1 || return 0
 }
 
+function update_etc_hosts() {
+    # $1 - IP
+    # $2 - hostname
+    grep -q "$2" /etc/hosts || echo "$1 $2" >> /etc/hosts
+}
+
+update_etc_hosts "$lb_ip" "$lb_hostname.$domainname"
+
 [ "$skip_ansible" == "True" ] && exit 0
 
 mkdir -p /var/lib/ansible/group_vars

--- a/fragments/master-boot.sh
+++ b/fragments/master-boot.sh
@@ -22,7 +22,7 @@ set -o pipefail
 source /usr/local/share/openshift-on-openstack/common_functions.sh
 source /usr/local/share/openshift-on-openstack/common_openshift_functions.sh
 
-[ "$SKIP_DNS" != "true" ] && add_nameserver $DNS_IP
+[ "$SKIP_DNS" != "True" ] && add_nameserver $DNS_IP
 
 disable_peerdns eth0
 ifup eth1

--- a/fragments/node-boot.sh
+++ b/fragments/node-boot.sh
@@ -20,7 +20,7 @@ set -o pipefail
 source /usr/local/share/openshift-on-openstack/common_functions.sh
 source /usr/local/share/openshift-on-openstack/common_openshift_functions.sh
 
-[ "$SKIP_DNS" != "true" ] && add_nameserver $DNS_IP
+[ "$SKIP_DNS" != "True" ] && add_nameserver $DNS_IP
 
 disable_peerdns eth0
 ifup eth1

--- a/templates/var/lib/ansible/group_vars/OSv3.yml
+++ b/templates/var/lib/ansible/group_vars/OSv3.yml
@@ -8,8 +8,10 @@ osm_default_subdomain: cloudapps.{{domainname}} # default subdomain to use for e
 openshift_override_hostname_check: true
 openshift_use_openshift_sdn: {{openshift_use_openshift_sdn}}
 openshift_use_flannel: {{openshift_use_flannel}}
-openshift_use_dnsmasq: false
 flannel_interface: eth1
+{{^skip_dns}}
+openshift_use_dnsmasq: false
+{{/skip_dns}}
 {{#master_ha}}
 openshift_master_cluster_password: openshift_cluster
 openshift_master_cluster_method: native

--- a/templates/var/lib/ansible/playbooks/dns.yml
+++ b/templates/var/lib/ansible/playbooks/dns.yml
@@ -1,4 +1,21 @@
 {{=<% %>=}}
+<%#skip_dns%>
+- hosts: nodes
+  sudo: yes
+  tasks:
+  - name: Copy /etc/hosts
+    copy: src=/etc/hosts dest=/etc/hosts owner=root group=root mode=0644
+
+<%#dedicated_lb%>
+- hosts: loadbalancer
+  sudo: yes
+  tasks:
+  - name: Copy /etc/hosts
+    copy: src=/etc/hosts dest=/etc/hosts owner=root group=root mode=0644
+<%/dedicated_lb%>
+<%/skip_dns%>
+
+<%^skip_dns%>
 - name: Gather facts
   hosts: nodes
   gather_facts: False
@@ -49,4 +66,5 @@
         src: "/var/lib/ansible/templates/etc/resolv.conf"
         dest: "/etc/resolv.conf"
       when: not openshift.common.is_containerized | bool
+<%/skip_dns%>
 <%={{ }}=%>

--- a/templates/var/lib/ansible/playbooks/main.yml
+++ b/templates/var/lib/ansible/playbooks/main.yml
@@ -1,7 +1,6 @@
 {{=<% %>=}}
-<%^skip_dns%>
 - include: /var/lib/ansible/playbooks/dns.yml
-<%/skip_dns%>
+
 <%#ansible_first_run%>
 <%#deploy_registry%>
 <%#prepare_registry%>

--- a/templates/var/lib/ansible/playbooks/scaleup.yml
+++ b/templates/var/lib/ansible/playbooks/scaleup.yml
@@ -1,7 +1,5 @@
 {{=<% %>=}}
-<%^skip_dns%>
 - include: /var/lib/ansible/playbooks/dns.yml
-<%/skip_dns%>
 
 - include: /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-node/scaleup.yml
   vars:


### PR DESCRIPTION
If skip_dns=true is used, DNS server is not deployed
on bastion node. Instead openshift-ansible deploys
dnsmasq on each node.
