### PR TITLE
Write template files in post cloud-init phase

### DIFF
--- a/bastion.yaml
+++ b/bastion.yaml
@@ -273,63 +273,6 @@ resources:
         - path: /root/.ssh/id_rsa.pub
           permissions: 0600
           content: {get_param: ansible_public_key}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/templates/etc/resolv.conf
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/templates/etc/resolv.conf}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/masters.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/group_vars/masters.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/nodes.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/group_vars/nodes.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/host_vars/loadbalancer.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/host_vars/loadbalancer.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/OSv3.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/group_vars/OSv3.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/registry.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/playbooks/registry.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/dns.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/playbooks/dns.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/main.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/playbooks/main.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/scaleup.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/playbooks/scaleup.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/scaledown.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/playbooks/scaledown.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/inventory
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/inventory}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/haproxy.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/playbooks/haproxy.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/templates/etc/haproxy/router.cfg.j2
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/templates/etc/haproxy/router.cfg.j2}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/ipfailover.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/playbooks/ipfailover.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/flannel.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/playbooks/flannel.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/quota.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/playbooks/quota.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/roles/reboot/tasks/main.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/roles/reboot/tasks/main.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml}
-        - path: /var/lib/os-apply-config/templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml
-          permissions: 0644
-          content: {get_file: templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
@@ -388,6 +331,44 @@ resources:
           params:
             $SYSTEM_UPDATE: {get_param: system_update}
           template: {get_file: fragments/host-update.sh}
+
+  write_templates:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      config:
+        list_join:
+        - "\n"
+        - - "#!/bin/bash"
+          - "set -eux"
+          - get_file: templates/var/lib/ansible/templates/etc/resolv.conf
+          - get_file: templates/var/lib/ansible/group_vars/masters.yml
+          - get_file: templates/var/lib/ansible/group_vars/nodes.yml
+          - get_file: templates/var/lib/ansible/host_vars/loadbalancer.yml
+          - get_file: templates/var/lib/ansible/group_vars/OSv3.yml
+          - get_file: templates/var/lib/ansible/playbooks/registry.yml
+          - get_file: templates/var/lib/ansible/playbooks/dns.yml
+          - get_file: templates/var/lib/ansible/playbooks/main.yml
+          - get_file: templates/var/lib/ansible/playbooks/scaleup.yml
+          - get_file: templates/var/lib/ansible/playbooks/scaledown.yml
+          - get_file: templates/var/lib/ansible/inventory
+          - get_file: templates/var/lib/ansible/playbooks/haproxy.yml
+          - get_file: templates/var/lib/ansible/templates/etc/haproxy/router.cfg.j2
+          - get_file: templates/var/lib/ansible/playbooks/ipfailover.yml
+          - get_file: templates/var/lib/ansible/playbooks/flannel.yml
+          - get_file: templates/var/lib/ansible/playbooks/quota.yml
+          - get_file: templates/var/lib/ansible/roles/reboot/tasks/main.yml
+          - get_file: templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml
+          - get_file: templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml
+
+  deployment_write_templates:
+    depends_on: wait_condition
+    type: OS::Heat::SoftwareDeployment
+    properties:
+      config:
+        get_resource: write_templates
+      server:
+        get_resource: host
 
   # Apply ansible performance tuning values
   tune_ansible:

--- a/templates/var/lib/ansible/group_vars/OSv3.yml
+++ b/templates/var/lib/ansible/group_vars/OSv3.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/group_vars
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/OSv3.yml
 ansible_first_run: {{ansible_first_run}}
 bastion_instance_id: {{bastion_instance_id}}
 ansible_ssh_user: {{ssh_user}}
@@ -65,3 +67,4 @@ openshift_hosted_registry_storage_openstack_filesystem: {{registry_volume_fs}}
 {{/openstack_cloud_provider}}
 openshift_hosted_manage_registry: {{deploy_registry}}
 openshift_hosted_manage_router: {{deploy_router}}
+EOF

--- a/templates/var/lib/ansible/group_vars/masters.yml
+++ b/templates/var/lib/ansible/group_vars/masters.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/group_vars
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/masters.yml
 num_infra: {{infra_count}}
 router_vip: {{router_vip}}
 openshift_schedulable: true
@@ -8,3 +10,4 @@ openshift_hosted_router_selector: region=infra
 {{^deploy_router}}
 openshift_hosted_router_replicas: 0
 {{/deploy_router}}
+EOF

--- a/templates/var/lib/ansible/group_vars/nodes.yml
+++ b/templates/var/lib/ansible/group_vars/nodes.yml
@@ -1,3 +1,6 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/group_vars
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/nodes.yml
 {{#volume_quota}}
 openshift_node_local_quota_per_fsgroup: {{ volume_quota }}Gi
 {{/volume_quota}}
+EOF

--- a/templates/var/lib/ansible/host_vars/loadbalancer.yml
+++ b/templates/var/lib/ansible/host_vars/loadbalancer.yml
@@ -1,4 +1,7 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/host_vars
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/host_vars/loadbalancer.yml
 ansible_ssh_host: {{lb_ip}}
 ansible_hostname: {{lb_hostname}}
 ansible_default_ipv4:
     address: {{lb_ip}}
+EOF

--- a/templates/var/lib/ansible/inventory
+++ b/templates/var/lib/ansible/inventory
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/inventory
 # Create an OSEv3 group that contains the masters and nodes groups
 [OSv3:children]
 bastion
@@ -49,3 +51,4 @@ localhost
 [extradnsitems]
 loadbalancer
 {{/no_lb}}
+EOF

--- a/templates/var/lib/ansible/playbooks/dns.yml
+++ b/templates/var/lib/ansible/playbooks/dns.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/playbooks
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/dns.yml
 {{=<% %>=}}
 - name: Gather facts
   hosts: nodes
@@ -62,3 +64,4 @@
         dest: "/etc/resolv.conf"
       when: not openshift.common.is_containerized | bool
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/playbooks/flannel.yml
+++ b/templates/var/lib/ansible/playbooks/flannel.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/playbooks
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/flannel.yml
 {{=<% %>=}}
 - hosts: nodes
   sudo: yes
@@ -11,3 +13,4 @@
   - name: Make iptables rules permanent
     shell: /usr/libexec/iptables/iptables.init save
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/playbooks/haproxy.yml
+++ b/templates/var/lib/ansible/playbooks/haproxy.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/playbooks
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/haproxy.yml
 {{=<% %>=}}
 - name: Gather facts
   hosts: infra
@@ -37,3 +39,4 @@
         enabled: yes
       register: start_result
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/playbooks/ipfailover.yml
+++ b/templates/var/lib/ansible/playbooks/ipfailover.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/playbooks
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/ipfailover.yml
 ---
 {{=<% %>=}}
 - hosts: masters[0]
@@ -21,3 +23,4 @@
   - name: Allow multicast for keepalived
     command: /sbin/iptables -I INPUT -i eth0 -d 224.0.0.18/32 -j ACCEPT
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/playbooks/main.yml
+++ b/templates/var/lib/ansible/playbooks/main.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/playbooks
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/main.yml
 {{=<% %>=}}
 <%^skip_dns%>
 - include: /var/lib/ansible/playbooks/dns.yml
@@ -97,3 +99,4 @@
 <%/deploy_router%>
 
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/playbooks/quota.yml
+++ b/templates/var/lib/ansible/playbooks/quota.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/playbooks
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/quota.yml
 ---
 - name: Apply gquota options to XFS mount points
   hosts: masters, nodes
@@ -7,3 +9,4 @@
       fmo_mount_options: "gquota"
     - role: xfs_grub_quota
     - role: reboot
+EOF

--- a/templates/var/lib/ansible/playbooks/registry.yml
+++ b/templates/var/lib/ansible/playbooks/registry.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/playbooks
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/registry.yml
 ---
 {{=<% %>=}}
 - hosts: localhost
@@ -47,3 +49,4 @@
   - name: Detach the volume to the VM
     shell: nova --os-auth-url {{ openshift_cloudprovider_openstack_auth_url }} --os-username {{ openshift_cloudprovider_openstack_username }} --os-password {{ openshift_cloudprovider_openstack_password }} --os-tenant-name {{ openshift_cloudprovider_openstack_tenant_name }} volume-detach {{ bastion_instance_id }} {{ openshift_hosted_registry_storage_openstack_volumeID }}
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/playbooks/scaledown.yml
+++ b/templates/var/lib/ansible/playbooks/scaledown.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/playbooks
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/scaledown.yml
 {{=<% %>=}}
 - name: Remove OpenShift node
   hosts: masters[0]
@@ -19,3 +21,4 @@
     - name: Remove node from list node list
       action: shell oc --config ~/.kube/config delete node {{ node }}
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/playbooks/scaleup.yml
+++ b/templates/var/lib/ansible/playbooks/scaleup.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/playbooks
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/scaleup.yml
 {{=<% %>=}}
 <%^skip_dns%>
 - include: /var/lib/ansible/playbooks/dns.yml
@@ -20,3 +22,4 @@
   - name: Restart node service
     service: name={{openshift.common.service_type}}-node state=restarted
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml
+++ b/templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/roles/fstab_mount_options/tasks/
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml
 {{=<% %>=}}
 ---
 - name: grab mount point line from fstab
@@ -33,3 +35,4 @@
     dump: "{{ mount_opts[4] }}"
     passno: "{{ mount_opts[5] }}"
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/roles/reboot/tasks/main.yml
+++ b/templates/var/lib/ansible/roles/reboot/tasks/main.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/roles/reboot/tasks/
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/roles/reboot/tasks/main.yml
 {{=<% %>=}}
 ---
 - name: Reboot server
@@ -13,3 +15,4 @@
   sudo: no
   local_action: wait_for host="{{ inventory_hostname }}" search_regex=OpenSSH port=22 timeout=300 state=started
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml
+++ b/templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/roles/xfs_grub_quota/tasks
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml
 {{=<% %>=}}
 ---
 - name: update kernel command line to add gquota
@@ -6,3 +8,4 @@
 - name: regenerate grub configuration
   shell: /sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/templates/etc/haproxy/router.cfg.j2
+++ b/templates/var/lib/ansible/templates/etc/haproxy/router.cfg.j2
@@ -1,3 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/templates/etc/haproxy
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/templates/etc/haproxy/router.cfg.j2
 {{=<% %>=}}
 frontend  atomic-openshift-router-http
     bind *:80
@@ -25,3 +27,4 @@ backend atomic-openshift-router-https
     server {{ hostvars[server].ansible_hostname }} {{ hostvars[server]['ansible_default_ipv4'].address }}:443 check
 {% endfor %}
 <%={{ }}=%>
+EOF

--- a/templates/var/lib/ansible/templates/etc/resolv.conf
+++ b/templates/var/lib/ansible/templates/etc/resolv.conf
@@ -1,2 +1,5 @@
+mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/templates/etc
+cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/templates/etc/resolv.conf
 nameserver {{dns_ip}}
 search {{domainname}}
+EOF


### PR DESCRIPTION
To avoid hitting 64K user-data limit, this patch moves
writing of template files into a SW Config script.
