### PR TITLE
add required RPM repos for RHEL install

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,6 +65,25 @@ inter-node communication).
 
 CentOS and RHEL are the only tested distros for now.
 
+=== Red Hat Software Repositories
+
+When installing OpenShift Enterprise on RHEL the OpenShift and
+OpenStack repositories must be enabled, along with several common
+repositories. These repositories must be available under the
+subscription account used for installation.
+
+.Required Repositories for RHEL installation
+|===
+|Repo Name |Purpose
+
+|rhel-7-server-rpms | Standard RHEL Server RPMs
+|rhel-7-server-extras-rpms | Supporting RPMs
+|rhel-7-server-optional-rpms | Supporting RPMs
+|rhel-7-server-openstack-8-rpms | OpenStack client and data collection RPMs
+|rhel-7-server-openstack-8-director-rpms | OpenStack data collection RPMs
+|rhel-7-server-ose-3.3-rpms | OpenShift Container Platform RPMs
+|===
+
 == Creating an All-In-One Demo Environment
 
 Following steps can be used to setup all-in-one testing/developer environment:


### PR DESCRIPTION
This patch adds a table of RPM repositories that must be available for users installing OpenShift on OpenStack using RHEL hosts.
