### PR TITLE
Add default loadbalancer neutron env file

### DIFF
--- a/env_loadbalancer_neutron.yaml
+++ b/env_loadbalancer_neutron.yaml
@@ -1,0 +1,6 @@
+parameters:
+    loadbalancer_type: 'neutron'
+
+resource_registry:
+    OOShift::LoadBalancer: loadbalancer_neutron.yaml
+    OOShift::IPFailover: ipfailover_keepalived.yaml


### PR DESCRIPTION
By default neutron LB is used and required option/mapping
is set in example env files. For consistency it should be also
possible to use this env file explicitly (as stated in README).
