### PR TITLE
Ignore "oadm ipfailover" error state

### DIFF
--- a/templates/var/lib/ansible/playbooks/ipfailover.yml
+++ b/templates/var/lib/ansible/playbooks/ipfailover.yml
@@ -16,6 +16,10 @@ cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/ipfa
   - name: Deploy Openshift IP failover for router
     command: oadm ipfailover --create --service-account=ipfailover --interface=eth0 --selector='region=infra' --replicas={{ num_infra }} --virtual-ips="{{ router_vip }}" --credentials=/etc/origin/master/openshift-router.kubeconfig
     when: ansible_first_run | default(false) | bool
+    # oadm ipfailover returns error code if service account already exists even
+    # if ipfailover pod is created successfully
+    # remove when https://bugzilla.redhat.com/show_bug.cgi?id=1332432 is fixed
+    ignore_errors: yes
 
 - hosts: masters
   sudo: yes


### PR DESCRIPTION
"oadm ipfailover" in OSE 3.3 returns error code if
"ipfailover" service account already exists (and it must
exist because privileges have to be set on it) but
ipfailover pod is created properly.

Ignore this error (check if ipfailover pod is actually running is done
main playbook anyway) until https://bugzilla.redhat.com/show_bug.cgi?id=1332432
is fixed.
