### PR TITLE
Fixed schduling on master nodes

### DIFF
--- a/templates/var/lib/ansible/group_vars/masters.yml
+++ b/templates/var/lib/ansible/group_vars/masters.yml
@@ -2,7 +2,7 @@ mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/group_vars
 cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/group_vars/masters.yml
 num_infra: {{infra_count}}
 router_vip: {{router_vip}}
-openshift_schedulable: true
+openshift_schedulable: false
 openshift_master_api_port: 8443
 {{#deploy_router}}
 openshift_hosted_router_selector: region=infra

--- a/templates/var/lib/ansible/playbooks/main.yml
+++ b/templates/var/lib/ansible/playbooks/main.yml
@@ -81,13 +81,6 @@ cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/main
 - hosts: masters[0]
   sudo: yes
   tasks:
-  - name: Disable scheduling on master nodes
-    shell: oadm manage-node {{ item }} --schedulable=false
-    with_items: "{{groups['masters']}}"
-
-- hosts: masters[0]
-  sudo: yes
-  tasks:
   - name: Clean pods in DeadlineExceeded status
     shell: oc get pod | grep DeadlineExceeded | cut -f 1 -d " " | xargs -r oc delete pod
 


### PR DESCRIPTION
Since dedicated infra nodes are used we can mark master
nodes as not schedulable directly in inventory file.

Fixes: #214
