### PR TITLE
Use new_nodes for scaleup

### DIFF
--- a/templates/var/lib/ansible/inventory
+++ b/templates/var/lib/ansible/inventory
@@ -6,6 +6,9 @@ bastion
 masters
 nodes
 etcd
+{{^ansible_first_run}}
+new_nodes
+{{/ansible_first_run}}
 {{#dedicated_lb}}
 lb
 
@@ -43,6 +46,13 @@ localhost
 {{#nodes}}
 {{.}} openshift_node_labels="{'region': 'primary', 'zone': 'default'}"
 {{/nodes}}
+
+{{^ansible_first_run}}
+[new_nodes]
+{{#new_nodes}}
+{{.}} openshift_node_labels="{'region': 'primary', 'zone': 'default'}"
+{{/new_nodes}}
+{{/ansible_first_run}}
 
 [dns]
 localhost

--- a/templates/var/lib/ansible/playbooks/scaleup.yml
+++ b/templates/var/lib/ansible/playbooks/scaleup.yml
@@ -9,14 +9,14 @@ cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/scal
   vars:
     openshift_infra_nodes: "{{ groups.infra | default([]) }}"
 
-- hosts: nodes
+- hosts: new_nodes
   sudo: yes
   tasks:
   - name: Allow docker traffic
     shell: iptables -A DOCKER -p tcp -j ACCEPT
     when: openshift_use_flannel
 
-- hosts: nodes
+- hosts: new_nodes
   sudo: yes
   tasks:
   - name: Restart node service


### PR DESCRIPTION
If 'new_nodes' group is defined, scaleup playbook uses
this group instead of the default 'nodes' group. This makes scaleup
process slightly faster because scaleup tasks are called only on
newly added nodes.
