### PR TITLE
Set openshift_master_cluster_hostname for external LB

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -297,7 +297,9 @@ openshift-on-openstack provides multiple options for setting up loadbalancing:
   for master nodes and OpenShift routers.
   This is suggested type for production.
   To select this type include `-e openshift-on-openstack/env_loadbalancer_external.yaml`
-  when creating the stack.
+  when creating the stack and also set `lb_hostname` parameter to point to the
+  loadbalancer's fully qualified domain name. Once stack creation is finished
+  you can set your external loadbalancer with the list of created master nodes.
 
 * Dedicated loadbalancer node - a dedicated node is created during stack
   creation and HAProxy loadbalancer is configured on it. Both console/API and

--- a/infra.yaml
+++ b/infra.yaml
@@ -94,7 +94,7 @@ parameters:
     type: string
     constraints:
     - allowed_pattern: '[a-z0-9\-]*'
-      description: Hostname must contain only characters [a-z0-9\-].
+      description: Hostname must contain only characters [a-z0-9\-\.].
 
   domain_name:
     description: >

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -38,8 +38,8 @@ parameters:
       The load balancer hostname portion of the FQDN
     type: string
     constraints:
-    - allowed_pattern: '[a-z0-9\-]*'
-      description: Hostname must contain only characters [a-z0-9\-].
+    - allowed_pattern: '[a-z0-9\-\.]*'
+      description: Hostname must contain only characters [a-z0-9\-\.].
 
   domain_name:
     description: >
@@ -161,6 +161,10 @@ parameters:
   skip_dns:
     type: boolean
 
+  stack_name:
+    description: Top level stack name.
+    type: string
+
 resources:
   floating_ip_assoc:
     type: OS::Neutron::FloatingIPAssociation
@@ -204,8 +208,9 @@ resources:
     properties:
       name:
         str_replace:
-          template: "%hostname%.%domainname%"
+          template: "%stack_name%-%hostname%.%domainname%"
           params:
+            '%stack_name%': {get_param: stack_name}
             '%hostname%': {get_param: hostname}
             '%domainname%': {get_param: domain_name}
       admin_user: {get_param: ssh_user}
@@ -235,13 +240,19 @@ resources:
     type: OS::Heat::CloudConfig
     properties:
       cloud_config:
-        hostname: {get_param: hostname}
+        hostname:
+          str_replace:
+            template: "%stack_name%-%hostname%"
+            params:
+              '%stack_name%': {get_param: stack_name}
+              '%hostname%': {get_param: hostname}
         fqdn:
           str_replace:
-            template: "HOST.DOMAIN"
+            template: "%stack_name%-%hostname%.%domainname%"
             params:
-              HOST: {get_param: hostname}
-              DOMAIN: {get_param: domain_name}
+              '%stack_name%': {get_param: stack_name}
+              '%hostname%': {get_param: hostname}
+              '%domainname%': {get_param: domain_name}
 
   # Compile a set of standard configuration files to provide identity and access
   included_files:
@@ -352,10 +363,11 @@ resources:
         node_type: loadbalancer
         node_name:
           str_replace:
-            template: "HOST.DOMAIN"
+            template: "%stack_name%-%hostname%.%domainname%"
             params:
-              HOST: {get_param: hostname}
-              DOMAIN: {get_param: domain_name}
+              '%stack_name%': {get_param: stack_name}
+              '%hostname%': {get_param: hostname}
+              '%domainname%': {get_param: domain_name}
       config:
         get_resource: node_cleanup
       server:
@@ -377,8 +389,9 @@ outputs:
     description: URL of the OpenShift web console
     value:
       str_replace:
-        template: "https://%hostname%.%domainname%:8443/console/"
+        template: "https://%stack_name%-%hostname%.%domainname%:8443/console/"
         params:
+          '%stack_name%': {get_param: stack_name}
           '%hostname%': {get_param: hostname}
           '%domainname%': {get_param: domain_name}
 
@@ -386,7 +399,18 @@ outputs:
     description: URL entrypoint to the OpenShift API
     value:
       str_replace:
-        template: "https://%hostname%.%domainname%:8443/"
+        template: "https://%stack_name%-%hostname%.%domainname%:8443/"
         params:
+          '%stack_name%': {get_param: stack_name}
+          '%hostname%': {get_param: hostname}
+          '%domainname%': {get_param: domain_name}
+
+  hostname:
+    description: Loadbalancer hostname
+    value:
+      str_replace:
+        template: "%stack_name%-%hostname%.%domainname%"
+        params:
+          '%stack_name%': {get_param: stack_name}
           '%hostname%': {get_param: hostname}
           '%domainname%': {get_param: domain_name}

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -36,8 +36,12 @@ parameters:
       The load balancer hostname portion of the FQDN
     type: string
     constraints:
-    - allowed_pattern: '[a-z0-9\-]*'
-      description: Hostname must contain only characters [a-z0-9\-].
+    - allowed_pattern: '[a-z0-9\-\.]*'
+      description: Hostname must contain only characters [a-z0-9\-\.].
+
+  stack_name:
+    description: Top level stack name.
+    type: string
 
   domain_name:
     description: >
@@ -164,16 +168,18 @@ outputs:
     description: URL of the OpenShift web console
     value:
       str_replace:
-        template: "https://%hostname%.%domainname%:8443/console/"
+        template: "https://%hostname%:8443/console/"
         params:
-          '%hostname%': {get_param: master_hostname}
-          '%domainname%': {get_param: domain_name}
+          '%hostname%': {get_param: hostname}
 
   api_url:
     description: URL entrypoint to the OpenShift API
     value:
       str_replace:
-        template: "https://%hostname%.%domainname%:8443/"
+        template: "https://%hostname%:8443/"
         params:
-          '%hostname%': {get_param: master_hostname}
-          '%domainname%': {get_param: domain_name}
+          '%hostname%': {get_param: hostname}
+
+  hostname:
+    description: Loadbalancer hostname
+    value: {get_param: hostname}

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -35,8 +35,12 @@ parameters:
       The load balancer hostname portion of the FQDN
     type: string
     constraints:
-    - allowed_pattern: '[a-z0-9\-]*'
-      description: Hostname must contain only characters [a-z0-9\-].
+    - allowed_pattern: '[a-z0-9\-\.]*'
+      description: Hostname must contain only characters [a-z0-9\-\.].
+
+  stack_name:
+    description: Top level stack name.
+    type: string
 
   domain_name:
     description: >
@@ -193,8 +197,9 @@ outputs:
     description: URL of the OpenShift web console
     value:
       str_replace:
-        template: "https://%hostname%.%domainname%:8443/console/"
+        template: "https://%stack_name%-%hostname%.%domainname%:8443/console/"
         params:
+          '%stack_name%': {get_param: stack_name}
           '%hostname%': {get_param: hostname}
           '%domainname%': {get_param: domain_name}
 
@@ -202,7 +207,18 @@ outputs:
     description: URL entrypoint to the OpenShift API
     value:
       str_replace:
-        template: "https://%hostname%.%domainname%:8443/"
+        template: "https://%stack_name%-%hostname%.%domainname%:8443/"
         params:
+          '%stack_name%': {get_param: stack_name}
+          '%hostname%': {get_param: hostname}
+          '%domainname%': {get_param: domain_name}
+
+  hostname:
+    description: Loadbalancer hostname
+    value:
+      str_replace:
+        template: "%stack_name%-%hostname%.%domainname%"
+        params:
+          '%stack_name%': {get_param: stack_name}
           '%hostname%': {get_param: hostname}
           '%domainname%': {get_param: domain_name}

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -35,6 +35,10 @@ parameters:
       The load balancer hostname portion of the FQDN
     type: string
 
+  stack_name:
+    description: Top level stack name.
+    type: string
+
   domain_name:
     description: >
       All VMs will be placed in this domain
@@ -142,6 +146,14 @@ parameters:
     type: number
     default: 4000
 
+  hostname:
+    description: >
+      The load balancer hostname portion of the FQDN
+    type: string
+    constraints:
+    - allowed_pattern: '[a-z0-9\-\.]*'
+      description: Hostname must contain only characters [a-z0-9\-\.].
+
   stack_name:
     type: string
     default: ''
@@ -172,4 +184,14 @@ outputs:
         template: "https://%hostname%.%domainname%:8443/"
         params:
           '%hostname%': {get_param: master_hostname}
+          '%domainname%': {get_param: domain_name}
+
+  hostname:
+    description: Loadbalancer hostname
+    value:
+      str_replace:
+        template: "%stack_name%-%hostname%.%domainname%"
+        params:
+          '%stack_name%': {get_param: stack_name}
+          '%hostname%': {get_param: hostname}
           '%domainname%': {get_param: domain_name}

--- a/master.yaml
+++ b/master.yaml
@@ -94,7 +94,7 @@ parameters:
     type: string
     constraints:
     - allowed_pattern: '[a-z0-9\-]*'
-      description: Hostname must contain only characters [a-z0-9\-].
+      description: Hostname must contain only characters [a-z0-9\-\.].
 
   domain_name:
     description: >

--- a/node.yaml
+++ b/node.yaml
@@ -128,7 +128,7 @@ parameters:
     type: string
     constraints:
     - allowed_pattern: '[a-z0-9\-]*'
-      description: Hostname must contain only characters [a-z0-9\-].
+      description: Hostname must contain only characters [a-z0-9\-\.].
 
   domain_name:
     description: >
@@ -204,6 +204,12 @@ parameters:
   lb_ip:
     description: >
       The IP address of the load balancer feeding the OpenShift master traffic
+    type: string
+    default: ''
+
+  master_ip:
+    description: >
+      The IP address of the first master node (used instead of external LB during setup)
     type: string
     default: ''
 
@@ -633,6 +639,8 @@ resources:
           default: {get_param: skip_dns}
         - name: lb_ip
           default: {get_param: lb_ip}
+        - name: master_ip
+          default: {get_param: master_ip}
         - name: lb_hostname
           default: {get_param: lb_hostname}
         - name: ldap_url

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -699,12 +699,8 @@ resources:
           loadbalancer_type: {get_param: loadbalancer_type}
           dns_forwarders: {get_param: dns_nameserver}
           lb_ip: {get_attr: [lb_floating_ip, floating_ip_address]}
-          lb_hostname:
-            str_replace:
-              template: "%stackname%-%hostname%"
-              params:
-                '%stackname%': {get_param: 'OS::stack_name'}
-                '%hostname%': {get_param: lb_hostname}
+          master_ip: {get_attr: [openshift_masters, resource.0.ip_address]}
+          lb_hostname: {get_attr: [loadbalancer, hostname]}
           router_vip: {get_attr: [ipfailover, router_vip]}
           skip_ansible: {get_param: skip_ansible}
           extra_openshift_ansible_params: {get_param: extra_openshift_ansible_params}
@@ -940,13 +936,9 @@ resources:
       sat6_activationkey: {get_param: sat6_activationkey}
       rhn_pool: {get_param: rhn_pool}
       extra_rhn_pools: {get_param: extra_rhn_pools}
-      hostname:
-        str_replace:
-          template: "%stackname%-%hostname%"
-          params:
-            '%stackname%': {get_param: 'OS::stack_name'}
-            '%hostname%': {get_param: lb_hostname}
+      hostname: {get_param: lb_hostname}
       domain_name: {get_param: domain_name}
+      stack_name: {get_param: 'OS::stack_name'}
       ansible_public_key: {get_attr: [ansible_keys, public_key]}
       dns_ip: {get_attr: [bastion_floating_ip, floating_ip_address]}
       fixed_subnet: {get_resource: fixed_subnet}

--- a/templates/var/lib/ansible/group_vars/OSv3.yml
+++ b/templates/var/lib/ansible/group_vars/OSv3.yml
@@ -19,8 +19,8 @@ openshift_master_cluster_password: openshift_cluster
 openshift_master_cluster_method: native
 {{/master_ha}}
 {{^no_lb}}
-openshift_master_cluster_hostname: {{lb_hostname}}.{{domainname}}
-openshift_master_cluster_public_hostname: {{lb_hostname}}.{{domainname}}
+openshift_master_cluster_hostname: {{lb_hostname}}
+openshift_master_cluster_public_hostname: {{lb_hostname}}
 {{/no_lb}}
 {{#ldap_url}}
 openshift_master_identity_providers:

--- a/templates/var/lib/ansible/host_vars/loadbalancer.yml
+++ b/templates/var/lib/ansible/host_vars/loadbalancer.yml
@@ -1,7 +1,7 @@
 mkdir -p /var/lib/os-apply-config/templates/var/lib/ansible/host_vars
 cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/host_vars/loadbalancer.yml
 ansible_ssh_host: {{lb_ip}}
-ansible_hostname: {{lb_hostname}}
+ansible_hostname: {{short_lb_hostname}}
 ansible_default_ipv4:
     address: {{lb_ip}}
 EOF

--- a/templates/var/lib/ansible/inventory
+++ b/templates/var/lib/ansible/inventory
@@ -57,8 +57,10 @@ localhost
 [dns]
 localhost
 {{^no_lb}}
+{{^external_lb}}
 
 [extradnsitems]
 loadbalancer
+{{/external_lb}}
 {{/no_lb}}
 EOF

--- a/templates/var/lib/ansible/playbooks/main.yml
+++ b/templates/var/lib/ansible/playbooks/main.yml
@@ -4,6 +4,18 @@ cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/main
 - include: /var/lib/ansible/playbooks/dns.yml
 
 <%#ansible_first_run%>
+<%#external_lb%>
+# an external LB can not be pre-set with master IPs because both creation
+# of master nodes and openshift-ansible are part of the same stack-create
+# process. Temporarily override external LB's IP to point to the first
+# master node. This IP is removed at the end of the first successful
+# setup.
+- hosts: all
+  tasks:
+  - name: Override external LB hostname's IP
+    lineinfile: dest=/etc/hosts regexp='.* <%lb_hostname%>' line="<%master_ip%> <%lb_hostname%>" state=present
+<%/external_lb%>
+
 <%#deploy_registry%>
 <%#prepare_registry%>
 - include: /var/lib/ansible/playbooks/registry.yml
@@ -89,6 +101,15 @@ cat << 'EOF' > /var/lib/os-apply-config/templates/var/lib/ansible/playbooks/main
 - include: /var/lib/ansible/playbooks/haproxy.yml
 <%/dedicated_lb%>
 <%/deploy_router%>
+
+<%#ansible_first_run%>
+<%#external_lb%>
+- hosts: all
+  tasks:
+  - name: Remove external LB hostname's IP
+    lineinfile: dest=/etc/hosts regexp='.* <%lb_hostname%>' state=absent
+<%/external_lb%>
+<%/ansible_first_run%>
 
 <%={{ }}=%>
 EOF


### PR DESCRIPTION
This patch sets openshift_master_cluster_hostname and
openshift_master_cluster_public_hostname to point to
an external LB hostname. Because the external LB can not
be pre-set with list of master nodes before openshift-ansible
runs, external LB's IP is overriden temporarily to point to
the first master node during first openshift-ansible run.

External loadbalancer hostname now can (and should) be fully
quilified domain name.
