### PR TITLE
Fix multiple ansible runs on the initial stack-create

### DIFF
--- a/templates/var/lib/ansible/inventory
+++ b/templates/var/lib/ansible/inventory
@@ -6,9 +6,7 @@ bastion
 masters
 nodes
 etcd
-{{^ansible_first_run}}
 new_nodes
-{{/ansible_first_run}}
 {{#dedicated_lb}}
 lb
 
@@ -47,8 +45,8 @@ localhost
 {{.}} openshift_node_labels="{'region': 'primary', 'zone': 'default'}"
 {{/nodes}}
 
-{{^ansible_first_run}}
 [new_nodes]
+{{^ansible_first_run}}
 {{#new_nodes}}
 {{.}} openshift_node_labels="{'region': 'primary', 'zone': 'default'}"
 {{/new_nodes}}


### PR DESCRIPTION
because [new_nodes] section was not added on the first ansible run,
then [new_nodes] section was added for the second node which caused
running scaleup playbook.