### PR TITLE
Wait for all nodes being added before running ansible

### DIFF
--- a/bastion.yaml
+++ b/bastion.yaml
@@ -7,6 +7,11 @@ description: >
 
 parameters:
 
+  node_count:
+    type: number
+    description: >
+      Number of non-master nodes to create.
+
   # What version of OpenShift Container Platform to install
   # This value is used to select the RPM repo for the OCP release to install
   ocp_version:
@@ -375,6 +380,29 @@ resources:
           - get_file: templates/var/lib/ansible/roles/reboot/tasks/main.yml
           - get_file: templates/var/lib/ansible/roles/fstab_mount_options/tasks/main.yml
           - get_file: templates/var/lib/ansible/roles/xfs_grub_quota/tasks/main.yml
+
+  update_node_count:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      inputs:
+        - name: node_count
+      config: |
+        #!/bin/bash
+        set -eux
+        mkdir -p /var/lib/ansible
+        echo "$node_count" > /var/lib/ansible/node_count
+
+  deployment_update_node_count:
+    depends_on: wait_condition
+    type: OS::Heat::SoftwareDeployment
+    properties:
+      config:
+        get_resource: update_node_count
+      server:
+        get_resource: host
+      input_values:
+        node_count: {get_param: node_count}
 
   deployment_write_templates:
     depends_on: wait_condition

--- a/node.yaml
+++ b/node.yaml
@@ -346,6 +346,12 @@ parameters:
     type: string
     description: Extra parameters for openshift-ansible
 
+  autoscaling:
+    type: boolean
+    description: >
+      Automatically scale up/down openshift nodes.
+    default: false
+
 resources:
 
   # Generate a string to distinguish one node from the others
@@ -704,6 +710,8 @@ resources:
           default: {get_param: volume_quota}
         - name: extra_openshift_ansible_params
           default: {get_param: extra_openshift_ansible_params}
+        - name: autoscaling
+          default: {get_param: autoscaling}
       outputs:
         - name: ca_cert
         - name: ca_key

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -549,6 +549,7 @@ resources:
     depends_on: [external_router_interface, fixed_network, fixed_subnet, registry_volume]
     type: bastion.yaml
     properties:
+      node_count: {get_param: node_count}
       ocp_version: {get_param: ocp_version}
       osp_version: {get_param: osp_version}
       ansible_version: {get_param: ansible_version}
@@ -680,6 +681,7 @@ resources:
       resource:
         type: node.yaml
         properties:
+          autoscaling: {get_param: autoscaling}
           ocp_version: {get_param: ocp_version}
           image: {get_param: node_image}
           flavor: {get_param: node_flavor}


### PR DESCRIPTION
Openshift compute ndoes are members of AutoscalingGroup in heat
stack, when each member is created it registers itself on
bastion node ("deployment_bastion_node_add" SW deployment in
templates), then a separate step ("deployment_run_ansible"
in node.yaml) configures openshift on all nodes which are
already registered.

It may happen that deployment_run_ansible is trigerred by
some node before all nodes are registered (by deployment_bastion_node_add)
which causes that then nodes are added in multiple ansible
runs/batches. It doesn't break setup and basically is
nothing bad with it but it makes creation or scale up
slower. It would be better to wait until deployment_bastion_node_add
is done for all nodes and then run deployment_run_ansible
only once for all nodes (AutoscalingGroup doesn't allow to do this easily though).

This patch uses node_count param to get desired number of nodes,
this can not work with autoscaling though so it's used only for
not-autoscaling create/update scenario.