### PR TITLE
replace references to OSE and OpenShift Enterprise to OCP and OpenShi…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -60,7 +60,7 @@ running:
 . http://www.centos.org/[CentOS] 7.2 cloud image (we leverage cloud-init)
 loaded in Glance for OpenShift Origin Deployments.
 https://access.redhat.com/downloads[RHEL]_ 7.2 cloud image if doing Atomic
-Enterprise or OpenShift Enterprise. Make sure to use official images to avoid
+Enterprise or OpenShift Container Platform. Make sure to use official images to avoid
 unexpected issues during deployment (e.g. a custom firewall may block OpenShift
 inter-node communication).
 . An SSH keypair loaded into Nova
@@ -70,7 +70,7 @@ CentOS and RHEL are the only tested distros for now.
 
 === Red Hat Software Repositories
 
-When installing OpenShift Enterprise on RHEL the OpenShift and
+When installing OpenShift Container Platform on RHEL the OpenShift and
 OpenStack repositories must be enabled, along with several common
 repositories. These repositories must be available under the
 subscription account used for installation.
@@ -138,7 +138,7 @@ two environment files are provided as examples.
 * ``env_origin.yaml`` is an example of the variables to deploy an OpenShift
   Origin 3 environment.
 * ``env_aop.yaml`` is an example of the variables to deploy an Atomic
-  Enterprise or OpenShift Enterprise 3 environment.  Note deployment type
+  Enterprise or OpenShift Container Platform 3 environment.  Note deployment type
   should be *openshift-enterprise* for OpenShift or *atomic-enterprise*
   for Atomic Enterprise.  Also, a valid RHN subscription is required
   for deployment.
@@ -154,7 +154,7 @@ this is how you deploy OpenShift Origin:
 ```yaml
 cat << EOF > openshift_parameters.yaml
 parameters:
-   # Use OpenShift Origin (vs OpenShift Enterprise)
+   # Use OpenShift Origin (vs OpenShift Container Platform)
    deployment_type: origin
 
    # set SSH access to VMs

--- a/bastion.yaml
+++ b/bastion.yaml
@@ -7,12 +7,12 @@ description: >
 
 parameters:
 
-  # What version of OpenShift Enterprise to install
-  # This value is used to select the RPM repo for the OSE release to install
-  ose_version:
+  # What version of OpenShift Container Platform to install
+  # This value is used to select the RPM repo for the OCP release to install
+  ocp_version:
     type: string
     description: >
-      The version of OpenShift Enterprise to deploy
+      The version of OpenShift Container Platform to deploy
 
   key_name:
     description: >
@@ -287,7 +287,7 @@ resources:
       config:
         str_replace:
           params:
-            $OSE_VERSION: {get_param: ose_version}
+            $OCP_VERSION: {get_param: ocp_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
             $SAT6_HOSTNAME: {get_param: sat6_hostname}

--- a/fragments/rhn-register.sh
+++ b/fragments/rhn-register.sh
@@ -11,8 +11,8 @@
 #   SAT6_ORGANIZAION - An Organization string to aid grouping of hosts
 #   SAT6_ACTIVATIONKEY - A string used to authorize the registration
 #
-#   OSE_VERSION - the version of the OS repo to enable
-OSE_VERSION=${OSE_VERSION:-"3.2"}
+#   OCP_VERSION - the version of the OS repo to enable
+OCP_VERSION=${OCP_VERSION:-"3.2"}
 
 # Exit on command fail
 set -eu
@@ -82,7 +82,7 @@ retry subscription-manager repos \
                      --enable="rhel-7-server-rpms" \
                      --enable="rhel-7-server-extras-rpms" \
                      --enable="rhel-7-server-optional-rpms" \
-                     --enable="rhel-7-server-ose-$OSE_VERSION-rpms"
+                     --enable="rhel-7-server-ose-$OCP_VERSION-rpms"
 
 # Allow RPM integrity checking
 rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/infra.yaml
+++ b/infra.yaml
@@ -7,12 +7,12 @@ description: >
 
 parameters:
 
-  # What version of OpenShift Enterprise to install
-  # This value is used to select the RPM repo for the OSE release to install
-  ose_version:
+  # What version of OpenShift Container Platform to install
+  # This value is used to select the RPM repo for the OCP release to install
+  ocp_version:
     type: string
     description: >
-      The version of OpenShift Enterprise to deploy
+      The version of OpenShift Container Platform to deploy
 
   key_name:
     description: >
@@ -352,7 +352,7 @@ resources:
       config:
         str_replace:
           params:
-            $OSE_VERSION: {get_param: ose_version}
+            $OCP_VERSION: {get_param: ocp_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
             $SAT6_HOSTNAME: {get_param: sat6_hostname}

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -5,12 +5,12 @@ description: >
 
 parameters:
 
-  # What version of OpenShift Enterprise to install
-  # This value is used to select the RPM repo for the OSE release to install
-  ose_version:
+  # What version of OpenShift Container Platform to install
+  # This value is used to select the RPM repo for the OCP release to install
+  ocp_version:
     type: string
     description: >
-      The version of OpenShift Enterprise to deploy
+      The version of OpenShift Container Platform to deploy
 
   key_name:
     description: >
@@ -280,7 +280,7 @@ resources:
       config:
         str_replace:
           params:
-            $OSE_VERSION: {get_param: ose_version}
+            $OCP_VERSION: {get_param: ocp_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
             $SAT6_HOSTNAME: {get_param: sat6_hostname}

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -6,12 +6,12 @@ description: >
 
 parameters:
 
-  # What version of OpenShift Enterprise to install
-  # This value is used to select the RPM repo for the OSE release to install
-  ose_version:
+  # What version of OpenShift Container Platform to install
+  # This value is used to select the RPM repo for the OCP release to install
+  ocp_version:
     type: string
     description: >
-      The version of OpenShift Enterprise to deploy
+      The version of OpenShift Container Platform to deploy
 
   key_name:
     description: >

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -5,12 +5,12 @@ description: >
 
 parameters:
 
-  # What version of OpenShift Enterprise to install
-  # This value is used to select the RPM repo for the OSE release to install
-  ose_version:
+  # What version of OpenShift Container Platform to install
+  # This value is used to select the RPM repo for the OCP release to install
+  ocp_version:
     type: string
     description: >
-      The version of OpenShift Enterprise to deploy
+      The version of OpenShift Container Platform to deploy
 
   key_name:
     description: >

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -5,12 +5,12 @@ description: >
 
 parameters:
 
-  # What version of OpenShift Enterprise to install
-  # This value is used to select the RPM repo for the OSE release to install
-  ose_version:
+  # What version of OpenShift Container Platform to install
+  # This value is used to select the RPM repo for the OCP release to install
+  ocp_version:
     type: string
     description: >
-      The version of OpenShift Enterprise to deploy
+      The version of OpenShift Container Platform to deploy
 
   key_name:
     description: >

--- a/master.yaml
+++ b/master.yaml
@@ -7,12 +7,12 @@ description: >
 
 parameters:
 
-  # What version of OpenShift Enterprise to install
-  # This value is used to select the RPM repo for the OSE release to install
-  ose_version:
+  # What version of OpenShift Container Platform to install
+  # This value is used to select the RPM repo for the OCP release to install
+  ocp_version:
     type: string
     description: >
-      The version of OpenShift Enterprise to deploy
+      The version of OpenShift Container Platform to deploy
 
   key_name:
     description: >
@@ -344,7 +344,7 @@ resources:
       config:
         str_replace:
           params:
-            $OSE_VERSION: {get_param: ose_version}
+            $OCP_VERSION: {get_param: ocp_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
             $SAT6_HOSTNAME: {get_param: sat6_hostname}

--- a/node.yaml
+++ b/node.yaml
@@ -7,12 +7,12 @@ description: >
 
 parameters:
 
-  # What version of OpenShift Enterprise to install
-  # This value is used to select the RPM repo for the OSE release to install
-  ose_version:
+  # What version of OpenShift Container Platform to install
+  # This value is used to select the RPM repo for the OCP release to install
+  ocp_version:
     type: string
     description: >
-      The version of OpenShift Enterprise to deploy
+      The version of OpenShift Container Platform to deploy
 
   key_name:
     description: >
@@ -446,7 +446,7 @@ resources:
       config:
         str_replace:
           params:
-            $OSE_VERSION: {get_param: ose_version}
+            $OCP_VERSION: {get_param: ocp_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
             $SAT6_HOSTNAME: {get_param: sat6_hostname}

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -7,13 +7,13 @@ description: >
 
 parameters:
 
-  # What version of OpenShift Enterprise to install
-  # This value is used to select the RPM repo for the OSE release to install
-  ose_version:
+  # What version of OpenShift Container Platform to install
+  # This value is used to select the RPM repo for the OCP release to install
+  ocp_version:
     type: string
     default: "3.2"
     description: >
-      The version of OpenShift Enterprise to deploy
+      The version of OpenShift Container Platform to deploy
 
   # Access to the VMs
   ssh_user:
@@ -516,7 +516,7 @@ resources:
     depends_on: [external_router_interface, fixed_network, fixed_subnet, registry_volume]
     type: bastion.yaml
     properties:
-      ose_version: {get_param: ose_version}
+      ocp_version: {get_param: ocp_version}
       image: {get_param: bastion_image}
       flavor: {get_param: bastion_flavor}
       key_name: {get_param: ssh_key_name}
@@ -557,7 +557,7 @@ resources:
       resource_def:
         type: master.yaml
         properties:
-          ose_version: {get_param: ose_version}
+          ocp_version: {get_param: ocp_version}
           image: {get_param: master_image}
           flavor: {get_param: master_flavor}
           key_name: {get_param: ssh_key_name}
@@ -600,7 +600,7 @@ resources:
       resource_def:
         type: infra.yaml
         properties:
-          ose_version: {get_param: ose_version}
+          ocp_version: {get_param: ocp_version}
           image: {get_param: infra_image}
           flavor: {get_param: infra_flavor}
           key_name: {get_param: ssh_key_name}
@@ -646,7 +646,7 @@ resources:
       resource:
         type: node.yaml
         properties:
-          ose_version: {get_param: ose_version}
+          ocp_version: {get_param: ocp_version}
           image: {get_param: node_image}
           flavor: {get_param: node_flavor}
           key_name: {get_param: ssh_key_name}
@@ -931,7 +931,7 @@ resources:
   loadbalancer:
     type:  OOShift::LoadBalancer
     properties:
-      ose_version: {get_param: ose_version}
+      ocp_version: {get_param: ocp_version}
       image: {get_param: loadbalancer_image}
       flavor: {get_param: loadbalancer_flavor}
       key_name: {get_param: ssh_key_name}


### PR DESCRIPTION
The name of the Red Hat version of OpenShift has been changed from "OpenShift Enterprise" to "OpenShift Container Platform".  This PR reflects this naming change.  It includes renaming variables and updating comment references to the new name.

There is no functional change in this PR.