### PR TITLE
Allow the user to select the OSP version on which the stack will run

### DIFF
--- a/bastion.yaml
+++ b/bastion.yaml
@@ -14,6 +14,14 @@ parameters:
     description: >
       The version of OpenShift Container Platform to deploy
 
+      # What version of OpenStack Platform to install
+  # This value is used to select the RPM repo for the OSP release to install
+  osp_version:
+    type: string
+    default: "10"
+    description: >
+      The version of OpenStack Platform to use to collect data
+
   key_name:
     description: >
       A pre-submitted SSH key to access the VM hosts
@@ -208,6 +216,8 @@ resources:
   # Install, configure and enable the Heat configuration agent
   config_agent:
     type: collect-config-setup/install_config_agent_centos_yum.yaml
+    properties:
+      osp_version: {get_param: osp_version}
 
   # Collect the results from a set of resources
   init:

--- a/collect-config-setup/fragments/configure_config_agent.sh
+++ b/collect-config-setup/fragments/configure_config_agent.sh
@@ -74,8 +74,7 @@ mkdir -p $oac_templates/var/run/heat-config
 echo "{{deployments}}" > $oac_templates/var/run/heat-config/heat-config
 
 # os-refresh-config scripts directory
-# This moves to /usr/libexec/os-refresh-config in later releases
-orc_scripts=/opt/stack/os-config-refresh
+orc_scripts=/usr/libexec/os-refresh-config
 for d in pre-configure.d configure.d migration.d post-configure.d; do
     install -m 0755 -o root -g root -d $orc_scripts/$d
 done

--- a/collect-config-setup/fragments/install_config_agent_yum.sh
+++ b/collect-config-setup/fragments/install_config_agent_yum.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eux
 
+# OSP_VERSION is set by ENV or by heat string replacement
+[ -n "$OSP_VERSION" ] || (echo "Missing required value OSP_VERSION" ; exit 1)
+
 # on Atomic host os-collect-config runs inside a container which is
 # fetched&started in another step
 [ -e /run/ostree-booted ] && exit 0
@@ -9,9 +12,11 @@ if ! yum info os-collect-config; then
     # if os-collect-config package is not available, first check if
     # the repo is available but disabled, otherwise install the package
     # from epel
-    if yum repolist disabled|grep rhel-7-server-openstack-8-director-rpms; then
-        subscription-manager repos --enable="rhel-7-server-openstack-8-director-rpms"
-        subscription-manager repos --enable="rhel-7-server-openstack-8-rpms"
+    if yum repolist disabled|grep rhel-7-server-openstack-${OSP_VERSION}-rpms; then
+        subscription-manager repos --enable="rhel-7-server-openstack-${OSP_VERSION}-rpms"
+        if [ "$OSP_VERSION" -lt 10 ] ; then
+            subscription-manager repos --enable="rhel-7-server-openstack-${OSP_VERSION}-director-rpms"
+        fi
     else
         yum -y install centos-release-openstack-liberty
     fi

--- a/collect-config-setup/install_config_agent_centos_yum.yaml
+++ b/collect-config-setup/install_config_agent_centos_yum.yaml
@@ -1,19 +1,32 @@
 heat_template_version: 2014-10-16
 
+parameters:
+
+  # What version of OpenStack Platform to install
+  # This value is used to select the RPM repo for the OSP release to install
+  osp_version:
+    type: string
+    default: "10"
+    description: >
+      The version of OpenStack Platform to use to collect data
+
 resources:
 
   install_config_agent_yum:
     type: "OS::Heat::SoftwareConfig"
     properties:
       group: ungrouped
-      config: {get_file: fragments/install_config_agent_yum.sh}
+      config:
+        str_replace:
+          params:
+            $OSP_VERSION: {get_param: osp_version}
+          template: {get_file: fragments/install_config_agent_yum.sh}
 
   configure_config_agent:
     type: "OS::Heat::SoftwareConfig"
     properties:
       group: ungrouped
-      config:
-        get_file: fragments/configure_config_agent.sh
+      config: {get_file: fragments/configure_config_agent.sh}
 
   start_config_agent:
     type: "OS::Heat::SoftwareConfig"

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -15,6 +15,14 @@ parameters:
     description: >
       The version of OpenShift Container Platform to deploy
 
+  # What version of OpenStack Platform to install
+  # This value is used to select the RPM repo for the OSP release to install
+  osp_version:
+    type: string
+    default: "10"
+    description: >
+      The version of OpenStack Platform to use to collect data
+
   # Access to the VMs
   ssh_user:
     type: string
@@ -517,6 +525,7 @@ resources:
     type: bastion.yaml
     properties:
       ocp_version: {get_param: ocp_version}
+      osp_version: {get_param: osp_version}
       image: {get_param: bastion_image}
       flavor: {get_param: bastion_flavor}
       key_name: {get_param: ssh_key_name}


### PR DESCRIPTION
The bastion host must communicate with the OSP service and gather host information from the other instances.  It uses the `os-collect-config` RPM to configure the communications and collect information.

The location of this package depends on the version of OSP in use.  The OSP RPM repo names change with the OSP version.

This patch allows the caller to set the OSP version so that the templates can install and configure the correct version of the `os-collect-config` package and prepare for operation.