### PR TITLE
allow a caller to specify the ansible version for OCP install

### DIFF
--- a/bastion.yaml
+++ b/bastion.yaml
@@ -14,13 +14,20 @@ parameters:
     description: >
       The version of OpenShift Container Platform to deploy
 
-      # What version of OpenStack Platform to install
+  # What version of OpenStack Platform to install
   # This value is used to select the RPM repo for the OSP release to install
   osp_version:
     type: string
     default: "10"
     description: >
       The version of OpenStack Platform to use to collect data
+
+  # Allow the caller to specify the version of ansible
+  ansible_version:
+    type: string
+    description: >
+      Set the RPM version of Ansible that will run on the bastion
+      If unset, use current version
 
   key_name:
     description: >
@@ -246,6 +253,7 @@ resources:
             $OPENSHIFT_ANSIBLE_GIT_URL: {get_param: openshift_ansible_git_url}
             $OPENSHIFT_ANSIBLE_GIT_REV: {get_param: openshift_ansible_git_rev}
             $DOCKER_VOLUME_ID: {get_resource: docker_volume}
+            $ANSIBLE_VERSION: {get_param: ansible_version}
           template: {get_file: fragments/bastion-boot.sh}
 
   # Compose the FQDN for cloud-init

--- a/fragments/bastion-boot.sh
+++ b/fragments/bastion-boot.sh
@@ -11,6 +11,8 @@
 #                               openshift ansible playbooks and configs
 #   OPENSHIFT_ANSIBLE_GIT_REV - the release/revision of the playbooks to use
 #
+#   ANSIBLE_VERSION  - the version of of ansible to use for OCP installation
+#
 
 # Exit on first command failure or undefined var reference
 set -eu
@@ -167,7 +169,12 @@ else
         install_epel_repos_disabled $EPEL_RELEASE_VERSION
         extra_opts="--enablerepo=epel"
     fi
-    retry yum -y $extra_opts install ansible ||
+    if [ -z "$ANSIBLE_VERSION" ] ; then
+        ANSIBLE_RPM="ansible"
+    else
+        ANSIBLE_RPM="ansible-$ANSIBLE_VERSION"
+    fi
+    retry yum -y $extra_opts install ${ANSIBLE_RPM}  ||
         notify_failure "could not install ansible"
 
     if [ -n "$OPENSHIFT_ANSIBLE_GIT_URL" -a -n "$OPENSHIFT_ANSIBLE_GIT_REV" ]; then

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -21,6 +21,14 @@ parameters:
     description: >
       The version of OpenStack Platform to use to collect data
 
+  # Allow the caller to specify the version of ansible
+  ansible_version:
+    type: string
+    default: ""
+    description: >
+      Set the RPM version of Ansible that will run on the bastion
+      If empty, use the current version
+
   # Access to the VMs
   ssh_user:
     type: string
@@ -536,6 +544,7 @@ resources:
     properties:
       ocp_version: {get_param: ocp_version}
       osp_version: {get_param: osp_version}
+      ansible_version: {get_param: ansible_version}
       image: {get_param: bastion_image}
       flavor: {get_param: bastion_flavor}
       key_name: {get_param: ssh_key_name}


### PR DESCRIPTION
This change allows the caller to override the ansible version used on the bastion host.