### PR TITLE
add constraints to skip_dns

### DIFF
--- a/env_loadbalancer_external.yaml
+++ b/env_loadbalancer_external.yaml
@@ -1,5 +1,6 @@
 parameters:
     loadbalancer_type: 'external'
+    skip_dns: False
 
 resource_registry:
     OOShift::LoadBalancer: loadbalancer_external.yaml

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -162,6 +162,7 @@ parameters:
 
   skip_dns:
     type: boolean
+    default: True
 
 outputs:
   console_url:

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -137,7 +137,11 @@ parameters:
       only, not by users). Instead dnsmasq is configured on each node by
       openshift-ansible (see openshift-ansible openshift_use_dnsmasq option
       for details).
-    default: false
+    default: False
+    constraints:
+      - allowed_values:
+          - True
+          - False
 
   system_update:
     type: boolean


### PR DESCRIPTION
The only correct value for the `skip_dns` is  "True|False".  

This change applies a constraint to the `skip_dns` parameter so that the caller is informed if an invalid value is provided. 