### PR TITLE
disable NetworkManager changes to host DNS

### DIFF
--- a/fragments/common_functions.sh
+++ b/fragments/common_functions.sh
@@ -23,6 +23,17 @@ function add_nameserver() {
     sed -i "/search openstacklocal.*/anameserver $1" /etc/resolv.conf
 }
 
+# Inform NetworkManager to ignore DNS related files (/etc/resolv.conf)
+function disable_nm_resolver_updates() {
+    if grep -q dns= /etc/NetworkManager/NetworkManager.conf ; then
+        # update the existing value
+        sed -i -e '/dns=/s/=.*/=none/' /etc/NetworkManager/NetworkManager.conf
+    else
+        # Add the desired value
+        sed -i -e '/\[main\]/adns=none' /etc/NetworkManager/NetworkManager.conf
+    fi
+}
+
 # All hosts must have an external disk device (cinder?) for docker storage
 function docker_set_storage_device() {
     # By default the cinder volume is mapped to virtio-first_20_chars of cinder

--- a/fragments/infra-boot.sh
+++ b/fragments/infra-boot.sh
@@ -21,6 +21,7 @@ source /usr/local/share/openshift-on-openstack/common_functions.sh
 source /usr/local/share/openshift-on-openstack/common_openshift_functions.sh
 
 [ "$SKIP_DNS" != "True" ] && add_nameserver $DNS_IP
+disable_nm_resolver_updates
 
 disable_peerdns eth0
 ifup eth1

--- a/fragments/master-boot.sh
+++ b/fragments/master-boot.sh
@@ -23,6 +23,7 @@ source /usr/local/share/openshift-on-openstack/common_functions.sh
 source /usr/local/share/openshift-on-openstack/common_openshift_functions.sh
 
 [ "$SKIP_DNS" != "True" ] && add_nameserver $DNS_IP
+disable_nm_resolver_updates
 
 disable_peerdns eth0
 ifup eth1

--- a/fragments/node-boot.sh
+++ b/fragments/node-boot.sh
@@ -21,6 +21,7 @@ source /usr/local/share/openshift-on-openstack/common_functions.sh
 source /usr/local/share/openshift-on-openstack/common_openshift_functions.sh
 
 [ "$SKIP_DNS" != "True" ] && add_nameserver $DNS_IP
+disable_nm_resolver_updates
 
 disable_peerdns eth0
 ifup eth1


### PR DESCRIPTION
This PR is a response to a change in NetworkManager behavior on RHEL 7.3.  With this change NetworkManager is instructed not to make any alterations to DNS related control files before attempting installation of OpenShift.  `openshift-ansible` restarts NetworkManager several times during the installation process, resulting in a faulty `/etc/resolv.conf` without this change.

The change is to add `dns=none` to the `[main]` section of the Network Manager configuration file:

    /etc/NetworkManager/NetworkManager.conf
    ...
    [main]
    dns=none
