### PR TITLE
Ansible debugging - switches allow stop before Ansible config generation and execution

### DIFF
--- a/fragments/bastion-ansible.sh
+++ b/fragments/bastion-ansible.sh
@@ -152,7 +152,7 @@ else
     update_etc_hosts "$lb_ip" "$lb_hostname"
 fi
 
-[ "$skip_ansible" == "True" ] && exit 0
+[ "$prepare_ansible" == "False" ] && exit 0
 
 mkdir -p /var/lib/ansible/group_vars
 mkdir -p /var/lib/ansible/host_vars
@@ -209,11 +209,16 @@ else
         /var/lib/ansible/playbooks/main.yml"
 fi
 
-if ! $cmd > $logfile 2>&1; then
-    tail -20 $logfile >&2
-    echo "Failed to run '$cmd', full log is in $(hostname):$logfile" >&2
-    exit 1
+if [ "$execute_ansible" == True ] ; then
+    if ! $cmd > $logfile 2>&1; then
+        tail -20 $logfile >&2
+        echo "Failed to run '$cmd', full log is in $(hostname):$logfile" >&2
+        exit 1
+    else
+        [ -e ${ANSDIR}.deployed ] && rm -rf ${ANSDIR}.deployed
+        mv ${ANSDIR}.started ${ANSDIR}.deployed
+    fi
 else
-    [ -e ${ANSDIR}.deployed ] && rm -rf ${ANSDIR}.deployed
-    mv ${ANSDIR}.started ${ANSDIR}.deployed
+    echo "INFO: ansible execution disabled"
+    echo "INFO: command = $cmd"
 fi

--- a/node.yaml
+++ b/node.yaml
@@ -285,11 +285,24 @@ parameters:
       True = Enable deployment of the OpenShift router
     type: boolean
 
-  # OpenShift installer (ansible) parameters
-  skip_ansible:
-    description: >
-      Disable host based installation/configuration
+  # OpenShift configuration: ansible controls
+  # These are for debugging.
+  #   Setting prepare_ansible=false will stop the stack before creating
+  #   installation config files
+  prepare_ansible:
     type: boolean
+    description: >
+      Create ansible configuration files for openshift-ansible playbooks
+    default: true
+
+  #   Setting execute_ansible=false will stop the stack before running
+  #   the ansible playbooks to install openshift, but *after* the configuration
+  #   files are generated
+  execute_ansible:
+    type: boolean
+    description: >
+      Run the ansible playbooks to install openshift
+    default: true
 
   # OpenStack access parameters
   # These allow the OpenShift service to view and use OpenStack resources
@@ -660,8 +673,10 @@ resources:
           default: {get_param: prepare_registry}
         - name: deploy_router
           default: {get_param: deploy_router}
-        - name: skip_ansible
-          default: {get_param: skip_ansible}
+        - name: prepare_ansible
+          default: {get_param: prepare_ansible}
+        - name: execute_ansible
+          default: {get_param: execute_ansible}
         - name: os_auth_url
           default: {get_param: os_auth_url}
         - name: os_username

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -1,9 +1,7 @@
 heat_template_version: 2014-10-16
 
-
 description: >
   Deploy Atomic/OpenShift 3 on OpenStack.
-
 
 parameters:
 
@@ -324,11 +322,23 @@ parameters:
     default: false
 
   # OpenShift configuration: ansible controls
-  skip_ansible:
+  # These are for debugging.
+  #   Setting prepare_ansible=false will stop the stack before creating
+  #   installation config files
+  prepare_ansible:
     type: boolean
     description: >
-      Do not install Openshift using Ansible.
-    default: false
+      Create ansible configuration files for openshift-ansible playbooks
+    default: true
+
+  #   Setting execute_ansible=false will stop the stack before running
+  #   the ansible playbooks to install openshift, but *after* the configuration
+  #   files are generated
+  execute_ansible:
+    type: boolean
+    description: >
+      Run the ansible playbooks to install openshift
+    default: true
 
   openshift_ansible_git_url:
     type: string
@@ -718,7 +728,8 @@ resources:
           master_ip: {get_attr: [openshift_masters, resource.0.ip_address]}
           lb_hostname: {get_attr: [loadbalancer, hostname]}
           router_vip: {get_attr: [ipfailover, router_vip]}
-          skip_ansible: {get_param: skip_ansible}
+          prepare_ansible: {get_param: prepare_ansible}
+          execute_ansible: {get_param: execute_ansible}
           extra_openshift_ansible_params: {get_param: extra_openshift_ansible_params}
 
   # Define the network access policy for openshift nodes


### PR DESCRIPTION
This change offers switches to developers to control the stack processing. It replaces one existing switch and adds one other.

* The `prepare_ansible` switch replaces and inverts the `skip_ansible` switch
* The `execute_ansible` switch is added.

Both switches default to `true` and are used only for development and debugging of the heat stack

= New Behavior

== `prepare_ansible`
When *true*, the stack script generates the ansible configuration scripts which will be used to install OpenShift on the target instances.

When *false* the stack script exits with success but stops processing before generating configuration or executing the ansible playbooks.

== `execute_ansible`
When *true* the stack script executes the openshift-ansible playbooks to install OpenShift on the target instances.

When *false* the stack script stops before running the playbooks and reports the `ansible-playbook` command which would have been executed.

When `prepare_ansible`
