### PR TITLE
fixed heat template replacement strings for OSP_VERSION

### DIFF
--- a/collect-config-setup/fragments/install_config_agent_yum.sh
+++ b/collect-config-setup/fragments/install_config_agent_yum.sh
@@ -12,10 +12,10 @@ if ! yum info os-collect-config; then
     # if os-collect-config package is not available, first check if
     # the repo is available but disabled, otherwise install the package
     # from epel
-    if yum repolist disabled|grep rhel-7-server-openstack-${OSP_VERSION}-rpms; then
-        subscription-manager repos --enable="rhel-7-server-openstack-${OSP_VERSION}-rpms"
+    if yum repolist disabled|grep rhel-7-server-openstack-$OSP_VERSION-rpms; then
+        subscription-manager repos --enable="rhel-7-server-openstack-$OSP_VERSION-rpms"
         if [ "$OSP_VERSION" -lt 10 ] ; then
-            subscription-manager repos --enable="rhel-7-server-openstack-${OSP_VERSION}-director-rpms"
+            subscription-manager repos --enable="rhel-7-server-openstack-$OSP_VERSION-director-rpms"
         fi
     else
         yum -y install centos-release-openstack-liberty


### PR DESCRIPTION
The replacement strings for Heat look like bourne shell environment variables but they are not.

Removed unneeded curly brackets from OSP_VERSION replacement strings.