### PR TITLE
enable injection of custom ca cert into trust chain

### DIFF
--- a/bastion.yaml
+++ b/bastion.yaml
@@ -196,6 +196,10 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # A VM to provide host based orchestration and other sub-services
@@ -230,6 +234,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -293,6 +298,15 @@ resources:
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: trusted_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Register the host with RHN for access to software packages
   rhn_register:

--- a/fragments/ca_cert.sh
+++ b/fragments/ca_cert.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Register with subscription manager and enable required RPM respositories
+#
+# ENVVARS:
+#   CA_CERT - a ca certificate to be added to trust chain
+
+# Exit on command fail
+set -eu
+set -x
+
+# Return the final non-zero exit code of a failed pipe (or 0 for success)
+set -o pipefail
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+if [ -n "$CA_CERT" ] ; then
+    update-ca-trust enable
+    cat >/etc/pki/ca-trust/source/anchors/ca.crt <<EOF
+$CA_CERT
+EOF
+    update-ca-trust extract
+else
+    exit 0
+fi

--- a/infra.yaml
+++ b/infra.yaml
@@ -220,6 +220,10 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # Create a network connection on the internal communications network
@@ -291,6 +295,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -337,6 +342,16 @@ resources:
               template: {get_file: fragments/ifcfg-eth}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: trusted_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Attach to a source of software updates for RHEL
   rhn_register:

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -158,6 +158,10 @@ parameters:
     description: Top level stack name.
     type: string
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
   floating_ip_assoc:
     type: OS::Neutron::FloatingIPAssociation
@@ -222,6 +226,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -265,6 +270,16 @@ resources:
               template: {get_file: fragments/common_functions.sh}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: trusted_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Connect to a software source for updates on RHEL
   rhn_register:

--- a/master.yaml
+++ b/master.yaml
@@ -213,6 +213,10 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # Create a network connection on the internal communications network
@@ -283,6 +287,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -329,6 +334,16 @@ resources:
               template: {get_file: fragments/ifcfg-eth}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: trusted_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Attach to a source of software updates for RHEL
   rhn_register:

--- a/node.yaml
+++ b/node.yaml
@@ -71,7 +71,7 @@ parameters:
       The password for the RHN user
     type: string
     hidden: true
-  
+
   # Red Hat satellite subscription parameters
   sat6_hostname:
     type: string
@@ -342,6 +342,10 @@ parameters:
     type: string
     description: Extra parameters for openshift-ansible
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # Generate a string to distinguish one node from the others
@@ -392,6 +396,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -444,6 +449,16 @@ resources:
               template: {get_file: fragments/ifcfg-eth}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: trusted_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Connect to software update source for RHEL
   rhn_register:

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -478,6 +478,11 @@ parameters:
     description: Extra parameters for openshift-ansible as a JSON string
     default: ""
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+    default: ''
+
 resources:
 
   # Network Components
@@ -567,6 +572,7 @@ resources:
       system_update: {get_param: system_update}
       extra_repository_urls: {get_param: extra_repository_urls}
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
+      trusted_ca_cert: {get_param: trusted_ca_cert}
 
   openshift_masters:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -608,6 +614,7 @@ resources:
           system_update: {get_param: system_update}
           extra_repository_urls: {get_param: extra_repository_urls}
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
+          trusted_ca_cert: {get_param: trusted_ca_cert}
 
   openshift_infra_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -650,6 +657,7 @@ resources:
           system_update: {get_param: system_update}
           extra_repository_urls: {get_param: extra_repository_urls}
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
+          trusted_ca_cert: {get_param: trusted_ca_cert}
 
   openshift_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -725,6 +733,7 @@ resources:
           prepare_ansible: {get_param: prepare_ansible}
           execute_ansible: {get_param: execute_ansible}
           extra_openshift_ansible_params: {get_param: extra_openshift_ansible_params}
+          trusted_ca_cert: {get_param: trusted_ca_cert}
 
   # Define the network access policy for openshift nodes
   node_security_group:

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -980,6 +980,7 @@ resources:
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
       stack_name: {get_param: 'OS::stack_name'}
       bastion_node: {get_attr: [bastion_host, resource.host]}
+      trusted_ca_cert: {get_param: trusted_ca_cert}
 
 outputs:
 


### PR DESCRIPTION
This allows you to enter a trusted ca cert to the openshift nodes and bastion host. This solves the issue https://bugzilla.redhat.com/show_bug.cgi?id=1419182 for me.

To use it, simply add a another parameter to your environment file as such:

  trusted_ca_cert: |
    -----BEGIN CERTIFICATE-----
    <... CERT CONTENT ...>
    -----END CERTIFICATE-----