### PR TITLE
Add support for dynamic DNS updates

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,9 +25,9 @@ connected by a private _software defined network_ (SDN) which can be
 implemented either with http://openvswitch.org/[OpenVSwitch] or https://github.com/coreos/flannel[Flannel].
 
 A _bastion server_ is used to control the host and service
-configuration.  It can also run local DNS services as
-needed. The host and service configuration is run using
-https://www.ansible.com/[Ansible] playbooks executed from the bastion host.
+configuration. The host and service configuration is run using
+https://www.ansible.com/[Ansible] playbooks executed from the bastion
+host.
 
 _Bastion server_, _master nodes_ and _infra nodes_ is also given a _floating IP_
 address on the public network. This provides direct access to the
@@ -67,6 +67,28 @@ inter-node communication).
 . A (Neutron) network with a pool of floating IP addresses available
 
 CentOS and RHEL are the only tested distros for now.
+
+=== DNS Server
+
+The OpenShift installer requires that all nodes be reachable via their
+hostnames. Since OpenStack does not currently provide an internal name
+resolution, this needs to be done with an external DNS service that
+all nodes use via the `dns_nameserver` parameter.
+
+In a production deployment this would be your existing DNS, but if you
+don't have the ability to update it to add new name records, you will
+have to deploy one yourself.
+
+We have provided a separate repository that can deploy a DNS server
+suitable for OpenShift:
+
+https://github.com/openshift/openshift-ansible-contrib/tree/master/reference-architecture/osp-dns
+
+NOTE: If your DNS supports dynamic updates via RFC 2136, you can pass
+the update key to the Heat stack and all nodes will register
+themselves as they come up. Otherwise, you will have to update your
+DNS records manually.
+
 
 === Red Hat Software Repositories
 
@@ -479,6 +501,17 @@ and `router_ip` is `172.24.4.168` there should be a DNS record for domain
 The above DNS records should be set on the DNS server authoritative for the
 domain used in OpenShift cluster (`example.com` in the example above).
 ====
+
+
+=== Dynamic DNS Updates
+
+If your DNS servers support dynamic updates (as defined in RFC 2136),
+you can pass the update key in the `dns_update_key` parameter and each
+node will register its internal IP address to all the DNS servers in
+the `dns_nameserver` list.
+
+You will still need to set the API and wildcard entries, though.
+
 
 == Retrieving the CA certificate
 

--- a/fragments/add_dns_record.sh
+++ b/fragments/add_dns_record.sh
@@ -20,7 +20,7 @@ fi
 
 HOSTNAME="$(hostname --fqdn)"
 
-for DNS_SERVER in "%DNS_SERVERS%"; do
+for DNS_SERVER in %DNS_SERVERS%; do
     # NOTE: the dot after the hostname is necessary
     /usr/local/bin/update_dns  -s "$DNS_SERVER" -k "$DNS_UPDATE_KEY" "$HOSTNAME." "%IP_ADDRESS%"
 done

--- a/fragments/add_dns_record.sh
+++ b/fragments/add_dns_record.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Update the DNS server with a record for this host
+
+set -eu
+set -x
+set -o pipefail
+
+DNS_UPDATE_KEY="%DNS_UPDATE_KEY%"
+
+if [ -z "$DNS_UPDATE_KEY" ]; then
+    echo "Skipping the DNS update because the key is empty."
+    exit
+fi
+
+if yum info python-dns; then
+    retry yum -y install python-dns
+else
+    retry yum -y install python2-dns
+fi
+
+HOSTNAME="$(hostname --fqdn)"
+
+for DNS_SERVER in "%DNS_SERVERS%"; do
+    # NOTE: the dot after the hostname is necessary
+    /usr/local/bin/update_dns  -s "$DNS_SERVER" -k "$DNS_UPDATE_KEY" "$HOSTNAME." "%IP_ADDRESS%"
+done

--- a/fragments/add_dns_record.sh
+++ b/fragments/add_dns_record.sh
@@ -20,7 +20,5 @@ fi
 
 HOSTNAME="$(hostname --fqdn)"
 
-for DNS_SERVER in %DNS_SERVERS%; do
-    # NOTE: the dot after the hostname is necessary
-    /usr/local/bin/update_dns  -s "$DNS_SERVER" -k "$DNS_UPDATE_KEY" "$HOSTNAME." "%IP_ADDRESS%"
-done
+# NOTE: the dot after the hostname is necessary
+/usr/local/bin/update_dns -z "%ZONE%" -s "%DNS_SERVER%" -k "$DNS_UPDATE_KEY" "$HOSTNAME." "%IP_ADDRESS%"

--- a/fragments/update_dns.py
+++ b/fragments/update_dns.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#
+# Add an A record to a DNS server via RFC 2136 dynamic update
+#
+
+from __future__ import print_function
+
+import os,sys
+from argparse import ArgumentParser
+
+# python2-dns
+import dns.query
+import dns.tsigkeyring
+import dns.update
+import dns.rcode
+
+
+def add_a_record(server, zone, key, name, address, ttl=300):
+
+    # make input zones absolute
+    #zone = zone + '.' if not zone.endswith('.')
+    keyring = dns.tsigkeyring.from_text({'update-key': key})
+    update = dns.update.Update(zone, keyring=keyring)
+    update.replace(name, ttl, 'a', address)
+    response = dns.query.tcp(update, server)
+    return response
+
+
+if __name__ == "__main__":
+
+    def process_arguments():
+        parser = ArgumentParser()
+        parser.add_argument("-s", "--server", type=str, default="127.0.0.1")
+        parser.add_argument("-z", "--zone", type=str, default="example.com")
+        parser.add_argument("-k", "--key", type=str, default=os.getenv("DNS_KEY"))
+        parser.add_argument("name", type=str)
+        parser.add_argument("address", type=str)
+        parser.add_argument("-t", "--ttl", type=str, default=300)
+        return parser.parse_args()
+
+    opts = process_arguments()
+    r = add_a_record(opts.server, opts.zone, opts.key, opts.name, opts.address, opts.ttl)
+
+    if r.rcode() != dns.rcode.NOERROR:
+        print("ERROR: update failed: {}".format(dns.rcode.to_text(r.rcode())))
+        sys.exit(r.rcode())
+

--- a/infra.yaml
+++ b/infra.yaml
@@ -411,7 +411,8 @@ resources:
       config:
         str_replace:
           params:
-            '%DNS_SERVERS%': {list_join: [" ", {get_param: dns_servers}]}
+            '%ZONE%': {get_param: domain_name}
+            '%DNS_SERVER%': {get_param: [dns_servers, 0]}
             '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
             '%IP_ADDRESS%': {get_attr: [port, fixed_ips, 0, ip_address]}
           template: {get_file: fragments/add_dns_record.sh}

--- a/infra.yaml
+++ b/infra.yaml
@@ -220,6 +220,14 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
+  dns_servers:
+    type: comma_delimited_list
+    description: address of dns nameservers reachable in your environment
+
+  dns_update_key:
+    type: string
+    hidden: true
+
 resources:
 
   # Create a network connection on the internal communications network
@@ -295,6 +303,7 @@ resources:
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
       - config: {get_resource: host_update}
+      - config: {get_resource: add_dns_record}
       - config: {get_resource: infra_boot}
 
   # Compose the short hostname and fully qualified domain name for the new host
@@ -329,6 +338,9 @@ resources:
         - path: /usr/local/bin/retry
           permissions: 0755
           content: {get_file: fragments/retry.sh}
+        - path: /usr/local/bin/update_dns
+          permissions: 0755
+          content: {get_file: fragments/update_dns.py}
         - path: /etc/sysconfig/network-scripts/ifcfg-eth1
           content:
             str_replace:
@@ -392,6 +404,17 @@ resources:
           params:
             $SYSTEM_UPDATE: {get_param: system_update}
           template: {get_file: fragments/host-update.sh}
+
+  add_dns_record:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            '%DNS_SERVERS%': {list_join: [" ", {get_param: dns_servers}]}
+            '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
+            '%IP_ADDRESS%': {get_attr: [port, fixed_ips, 0, ip_address]}
+          template: {get_file: fragments/add_dns_record.sh}
 
   # Prepare the host to run Docker and Ansible for OpenShift install and config
   infra_boot:

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -339,7 +339,8 @@ resources:
       config:
         str_replace:
           params:
-            '%DNS_SERVERS%': {list_join: [" ", {get_param: dns_servers}]}
+            '%ZONE%': {get_param: domain_name}
+            '%DNS_SERVER%': {get_param: [dns_servers, 0]}
             '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
             '%IP_ADDRESS%': {get_param: floatingip}
           template: {get_file: fragments/add_dns_record.sh}

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -114,6 +114,9 @@ parameters:
   floatingip_id:
     type: string
 
+  floatingip:
+    type: string
+
   fixed_network:
     description: >
       The name or ID of the internal network
@@ -157,6 +160,14 @@ parameters:
   stack_name:
     description: Top level stack name.
     type: string
+
+  dns_servers:
+    type: comma_delimited_list
+    description: address of dns nameservers reachable in your environment
+
+  dns_update_key:
+    type: string
+    hidden: true
 
 resources:
   floating_ip_assoc:
@@ -226,6 +237,7 @@ resources:
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
       - config: {get_resource: host_update}
+      - config: {get_resource: add_dns_record}
       - config: {get_resource: lb_boot}
 
   # Compose the FQDN and set the hostname in the cloud-init data structure
@@ -256,6 +268,9 @@ resources:
         - path: /usr/bin/retry
           permissions: 0755
           content: {get_file: fragments/retry.sh}
+        - path: /usr/local/bin/update_dns
+          permissions: 0755
+          content: {get_file: fragments/update_dns.py}
         - path: /usr/local/share/openshift-on-openstack/common_functions.sh
           permissions: 0755
           content:
@@ -318,13 +333,25 @@ resources:
       config:
         get_file: fragments/host-update.sh
 
+  add_dns_record:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            '%DNS_SERVERS%': {list_join: [" ", {get_param: dns_servers}]}
+            '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
+            '%IP_ADDRESS%': {get_param: floatingip}
+          template: {get_file: fragments/add_dns_record.sh}
+
+
   # Prepare the host for SSH access for ansible
   lb_boot:
     type: OS::Heat::SoftwareConfig
     properties:
       config:
         str_replace:
-          params:
+          params: {}
           template: {get_file: fragments/lb-boot.sh}
 
   node_cleanup:

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -116,6 +116,9 @@ parameters:
   floatingip_id:
     type: string
 
+  floatingip:
+    type: string
+
   fixed_network:
     description: >
       The name or ID of the internal network
@@ -155,6 +158,14 @@ parameters:
     description: >
       The name or ID of the bastion instance.
     default: ''
+
+  dns_servers:
+    type: comma_delimited_list
+    description: address of dns nameservers reachable in your environment
+
+  dns_update_key:
+    type: string
+    hidden: true
 
 outputs:
   console_url:

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -115,6 +115,9 @@ parameters:
   floatingip_id:
     type: string
 
+  floatingip:
+    type: string
+
   fixed_network:
     description: >
       The name or ID of the internal network
@@ -148,6 +151,14 @@ parameters:
     description: >
       The name or ID of the bastion instance.
     default: ''
+
+  dns_servers:
+    type: comma_delimited_list
+    description: address of dns nameservers reachable in your environment
+
+  dns_update_key:
+    type: string
+    hidden: true
 
 resources:
   lb:

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -112,6 +112,9 @@ parameters:
   floatingip_id:
     type: string
 
+  floatingip:
+    type: string
+
   fixed_network:
     description: >
       The name or ID of the internal network
@@ -159,6 +162,14 @@ parameters:
     description: >
       The name or ID of the bastion instance.
     default: ''
+
+  dns_servers:
+    type: comma_delimited_list
+    description: address of dns nameservers reachable in your environment
+
+  dns_update_key:
+    type: string
+    hidden: true
 
 outputs:
   console_url:

--- a/master.yaml
+++ b/master.yaml
@@ -213,6 +213,14 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
+  dns_servers:
+    type: comma_delimited_list
+    description: address of dns nameservers reachable in your environment
+
+  dns_update_key:
+    type: string
+    hidden: true
+
 resources:
 
   # Create a network connection on the internal communications network
@@ -287,6 +295,7 @@ resources:
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
       - config: {get_resource: host_update}
+      - config: {get_resource: add_dns_record}
       - config: {get_resource: master_boot}
 
   # Compose the short hostname and fully qualified domain name for the new host
@@ -321,6 +330,9 @@ resources:
         - path: /usr/local/bin/retry
           permissions: 0755
           content: {get_file: fragments/retry.sh}
+        - path: /usr/local/bin/update_dns
+          permissions: 0755
+          content: {get_file: fragments/update_dns.py}
         - path: /etc/sysconfig/network-scripts/ifcfg-eth1
           content:
             str_replace:
@@ -384,6 +396,17 @@ resources:
           params:
             $SYSTEM_UPDATE: {get_param: system_update}
           template: {get_file: fragments/host-update.sh}
+
+  add_dns_record:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            '%DNS_SERVERS%': {list_join: [" ", {get_param: dns_servers}]}
+            '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
+            '%IP_ADDRESS%': {get_attr: [port, fixed_ips, 0, ip_address]}
+          template: {get_file: fragments/add_dns_record.sh}
 
   # Prepare the host to run Docker and Ansible for OpenShift install and config
   master_boot:

--- a/master.yaml
+++ b/master.yaml
@@ -403,7 +403,8 @@ resources:
       config:
         str_replace:
           params:
-            '%DNS_SERVERS%': {list_join: [" ", {get_param: dns_servers}]}
+            '%ZONE%': {get_param: domain_name}
+            '%DNS_SERVER%': {get_param: [dns_servers, 0]}
             '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
             '%IP_ADDRESS%': {get_attr: [port, fixed_ips, 0, ip_address]}
           template: {get_file: fragments/add_dns_record.sh}

--- a/node.yaml
+++ b/node.yaml
@@ -71,7 +71,7 @@ parameters:
       The password for the RHN user
     type: string
     hidden: true
-  
+
   # Red Hat satellite subscription parameters
   sat6_hostname:
     type: string
@@ -325,9 +325,13 @@ parameters:
       The name of the OpenStack "region" to use to create or find resources
     type: string
 
-  dns_forwarders:
+  dns_servers:
     type: comma_delimited_list
     description: address of dns nameservers reachable in your environment
+
+  dns_update_key:
+    type: string
+    hidden: true
 
   router_vip:
     description: >
@@ -396,6 +400,7 @@ resources:
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
       - config: {get_resource: host_update}
+      - config: {get_resource: add_dns_record}
       - config: {get_resource: node_boot}
 
   # Compose the node identifiers: hostname and FQDN: provide them to cloud-init
@@ -436,6 +441,9 @@ resources:
         - path: /usr/local/bin/retry
           permissions: 0755
           content: {get_file: fragments/retry.sh}
+        - path: /usr/local/bin/update_dns
+          permissions: 0755
+          content: {get_file: fragments/update_dns.py}
         - path: /etc/sysconfig/network-scripts/ifcfg-eth1
           content:
             str_replace:
@@ -499,6 +507,18 @@ resources:
           params:
             $SYSTEM_UPDATE: {get_param: system_update}
           template: {get_file: fragments/host-update.sh}
+
+  add_dns_record:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            '%DNS_SERVERS%': {list_join: [" ", {get_param: dns_servers}]}
+            '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
+            '%IP_ADDRESS%': {get_attr: [port, fixed_ips, 0, ip_address]}
+          template: {get_file: fragments/add_dns_record.sh}
+
 
   # Prepare the node to run Docker and Ansible on first boot
   node_boot:
@@ -674,7 +694,7 @@ resources:
           default:
             list_join:
               - ","
-              - {get_param: dns_forwarders}
+              - {get_param: dns_servers}
         - name: bastion_instance_id
           default: {get_param: bastion_node}
         - name: router_vip

--- a/node.yaml
+++ b/node.yaml
@@ -514,7 +514,8 @@ resources:
       config:
         str_replace:
           params:
-            '%DNS_SERVERS%': {list_join: [" ", {get_param: dns_servers}]}
+            '%ZONE%': {get_param: domain_name}
+            '%DNS_SERVER%': {get_param: [dns_servers, 0]}
             '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
             '%IP_ADDRESS%': {get_attr: [port, fixed_ips, 0, ip_address]}
           template: {get_file: fragments/add_dns_record.sh}

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -137,6 +137,21 @@ parameters:
       These will be configured into the OpenStack networks. They are the
       namservers that new OpenShift instances will use.
 
+  dns_update_key:
+    type: string
+    description: >
+      A key for updating the DNS servers.
+
+      If specified, each node will update the `dns_nameserver` with
+      the A record of their hostname and internal IP address.
+
+      If left empty, no DNS updates will be performed. Note that the
+      OpenShift installation will fail if the nodes cannot resolve each
+      other. As such, this means you will have to update your DNS
+      servers manually.
+    hidden: true
+    default: ""
+
   system_update:
     type: boolean
     description: Run "yum update" on each node on first boot.
@@ -608,6 +623,8 @@ resources:
           system_update: {get_param: system_update}
           extra_repository_urls: {get_param: extra_repository_urls}
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
+          dns_servers: {get_param: dns_nameserver}
+          dns_update_key: {get_param: dns_update_key}
 
   openshift_infra_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -650,6 +667,8 @@ resources:
           system_update: {get_param: system_update}
           extra_repository_urls: {get_param: extra_repository_urls}
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
+          dns_servers: {get_param: dns_nameserver}
+          dns_update_key: {get_param: dns_update_key}
 
   openshift_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -717,7 +736,8 @@ resources:
           os_tenant_name: {get_param: os_tenant_name}
           os_region_name: {get_param: os_region_name}
           loadbalancer_type: {get_param: loadbalancer_type}
-          dns_forwarders: {get_param: dns_nameserver}
+          dns_servers: {get_param: dns_nameserver}
+          dns_update_key: {get_param: dns_update_key}
           lb_ip: {get_attr: [lb_floating_ip, floating_ip_address]}
           master_ip: {get_attr: [openshift_masters, resource.0.ip_address]}
           lb_hostname: {get_attr: [loadbalancer, hostname]}
@@ -965,12 +985,15 @@ resources:
       members: {get_attr: [openshift_masters, host]}
       master_hostname: {get_attr: [openshift_masters, resource.0.hostname]}
       floatingip_id: {get_resource: lb_floating_ip}
+      floatingip: {get_attr: [lb_floating_ip, floating_ip_address]}
       fixed_network: {get_resource: fixed_network}
       fixed_subnet: {get_resource: fixed_subnet}
       extra_repository_urls: {get_param: extra_repository_urls}
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
       stack_name: {get_param: 'OS::stack_name'}
       bastion_node: {get_attr: [bastion_host, resource.host]}
+      dns_servers: {get_param: dns_nameserver}
+      dns_update_key: {get_param: dns_update_key}
 
 outputs:
 


### PR DESCRIPTION
Passing the update key to `dns_update_key` will cause each node to
register with the specified DNS servers.