### PR TITLE
Create the wildcard DNS entry for the dedicated LB

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -510,7 +510,9 @@ you can pass the update key in the `dns_update_key` parameter and each
 node will register its internal IP address to all the DNS servers in
 the `dns_nameserver` list.
 
-You will still need to set the API and wildcard entries, though.
+In addition, if you use the *dedicated load balancer*, the API and
+wildcard entries will be created as well. Otherwise, you will need to
+set them manually.
 
 
 == Retrieving the CA certificate

--- a/fragments/add_dns_record.sh
+++ b/fragments/add_dns_record.sh
@@ -18,7 +18,13 @@ else
     retry yum -y install python2-dns
 fi
 
-HOSTNAME="$(hostname --fqdn)"
+
+NAME="%DNS_ENTRY%"
+
+# If we didn't get an explicit name, use this server's hostname
+if [ -n "$NAME" -a "${NAME:0:1}" = "%" -a "${NAME: -1}" = "%" ]; then
+    NAME="$(hostname)"
+fi
 
 # NOTE: the dot after the hostname is necessary
-/usr/local/bin/update_dns -z "%ZONE%" -s "%DNS_SERVER%" -k "$DNS_UPDATE_KEY" "$HOSTNAME." "%IP_ADDRESS%"
+/usr/local/bin/update_dns -z "%ZONE%" -s "%DNS_SERVER%" -k "$DNS_UPDATE_KEY" "$NAME." "%IP_ADDRESS%"

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -46,6 +46,9 @@ parameters:
       All VMs will be placed in this domain
     type: string
 
+  app_subdomain:
+    type: string
+
   rhn_username:
     description: >
       A valid user with entitlements to RHEL and OpenShift software repos
@@ -238,6 +241,7 @@ resources:
       - config: {get_resource: set_extra_docker_repos}
       - config: {get_resource: host_update}
       - config: {get_resource: add_dns_record}
+      - config: {get_resource: add_wildcard_record}
       - config: {get_resource: lb_boot}
 
   # Compose the FQDN and set the hostname in the cloud-init data structure
@@ -339,6 +343,19 @@ resources:
       config:
         str_replace:
           params:
+            '%ZONE%': {get_param: domain_name}
+            '%DNS_SERVER%': {get_param: [dns_servers, 0]}
+            '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
+            '%IP_ADDRESS%': {get_param: floatingip}
+          template: {get_file: fragments/add_dns_record.sh}
+
+  add_wildcard_record:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            '%DNS_ENTRY%': {list_join: ["", ["*.", {get_param: app_subdomain}]]}
             '%ZONE%': {get_param: domain_name}
             '%DNS_SERVER%': {get_param: [dns_servers, 0]}
             '%DNS_UPDATE_KEY%': {get_param: dns_update_key}

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -48,6 +48,9 @@ parameters:
       All VMs will be placed in this domain
     type: string
 
+  app_subdomain:
+    type: string
+
   rhn_username:
     description: >
       A valid user with entitlements to RHEL and OpenShift software repos

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -47,6 +47,9 @@ parameters:
       All VMs will be placed in this domain
     type: string
 
+  app_subdomain:
+    type: string
+
   rhn_username:
     description: >
       A valid user with entitlements to RHEL and OpenShift software repos

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -44,6 +44,9 @@ parameters:
       All VMs will be placed in this domain
     type: string
 
+  app_subdomain:
+    type: string
+
   rhn_username:
     description: >
       A valid user with entitlements to RHEL and OpenShift software repos

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -979,6 +979,7 @@ resources:
       extra_rhn_pools: {get_param: extra_rhn_pools}
       hostname: {get_param: lb_hostname}
       domain_name: {get_param: domain_name}
+      app_subdomain: {get_param: app_subdomain}
       stack_name: {get_param: 'OS::stack_name'}
       ansible_public_key: {get_attr: [ansible_keys, public_key]}
       fixed_subnet: {get_resource: fixed_subnet}


### PR DESCRIPTION
When using the dedicated load balancer, we're able to create the
wildcard entries for the OpenShift pods. So this does just that.