### PR TITLE
enable injection of custom ca cert into trust chain

### DIFF
--- a/bastion.yaml
+++ b/bastion.yaml
@@ -196,6 +196,10 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
+  osp_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # A VM to provide host based orchestration and other sub-services
@@ -230,6 +234,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -293,6 +298,15 @@ resources:
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: osp_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Register the host with RHN for access to software packages
   rhn_register:

--- a/fragments/ca_cert.sh
+++ b/fragments/ca_cert.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Register with subscription manager and enable required RPM respositories
+#
+# ENVVARS:
+#   CA_CERT - a ca certificate to be added to trust chain
+
+# Exit on command fail
+set -eu
+set -x
+
+# Return the final non-zero exit code of a failed pipe (or 0 for success)
+set -o pipefail
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+if [ -n "$CA_CERT" ] ; then
+    update-ca-trust enable
+    cat >/etc/pki/ca-trust/source/anchors/ca.crt <<EOF
+$CA_CERT
+EOF
+    update-ca-trust extract
+else
+    exit 0
+fi

--- a/infra.yaml
+++ b/infra.yaml
@@ -228,6 +228,10 @@ parameters:
     type: string
     hidden: true
 
+  osp_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # Create a network connection on the internal communications network
@@ -299,6 +303,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -349,6 +354,16 @@ resources:
               template: {get_file: fragments/ifcfg-eth}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: osp_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Attach to a source of software updates for RHEL
   rhn_register:

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -169,6 +169,10 @@ parameters:
     type: string
     hidden: true
 
+  osp_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
   floating_ip_assoc:
     type: OS::Neutron::FloatingIPAssociation
@@ -233,6 +237,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -280,6 +285,16 @@ resources:
               template: {get_file: fragments/common_functions.sh}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: osp_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Connect to a software source for updates on RHEL
   rhn_register:

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -167,6 +167,10 @@ parameters:
     type: string
     hidden: true
 
+  osp_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 outputs:
   console_url:
     description: URL of the OpenShift web console

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -160,6 +160,10 @@ parameters:
     type: string
     hidden: true
 
+  osp_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
   lb:
     type: OS::Neutron::LoadBalancer

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -171,6 +171,10 @@ parameters:
     type: string
     hidden: true
 
+  osp_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 outputs:
   console_url:
     description: URL of the OpenShift web console

--- a/master.yaml
+++ b/master.yaml
@@ -221,6 +221,10 @@ parameters:
     type: string
     hidden: true
 
+  osp_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # Create a network connection on the internal communications network
@@ -291,6 +295,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -341,6 +346,16 @@ resources:
               template: {get_file: fragments/ifcfg-eth}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: osp_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Attach to a source of software updates for RHEL
   rhn_register:

--- a/node.yaml
+++ b/node.yaml
@@ -346,6 +346,10 @@ parameters:
     type: string
     description: Extra parameters for openshift-ansible
 
+  osp_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # Generate a string to distinguish one node from the others
@@ -396,6 +400,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -452,6 +457,16 @@ resources:
               template: {get_file: fragments/ifcfg-eth}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: osp_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Connect to software update source for RHEL
   rhn_register:

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -493,6 +493,11 @@ parameters:
     description: Extra parameters for openshift-ansible as a JSON string
     default: ""
 
+  osp_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+    default: ''
+
 resources:
 
   # Network Components
@@ -582,6 +587,7 @@ resources:
       system_update: {get_param: system_update}
       extra_repository_urls: {get_param: extra_repository_urls}
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
+      osp_ca_cert: {get_param: osp_ca_cert}
 
   openshift_masters:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -625,6 +631,7 @@ resources:
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
           dns_servers: {get_param: dns_nameserver}
           dns_update_key: {get_param: dns_update_key}
+          osp_ca_cert: {get_param: osp_ca_cert}
 
   openshift_infra_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -669,6 +676,7 @@ resources:
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
           dns_servers: {get_param: dns_nameserver}
           dns_update_key: {get_param: dns_update_key}
+          osp_ca_cert: {get_param: osp_ca_cert}
 
   openshift_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -745,6 +753,7 @@ resources:
           prepare_ansible: {get_param: prepare_ansible}
           execute_ansible: {get_param: execute_ansible}
           extra_openshift_ansible_params: {get_param: extra_openshift_ansible_params}
+          osp_ca_cert: {get_param: osp_ca_cert}
 
   # Define the network access policy for openshift nodes
   node_security_group:
@@ -994,6 +1003,7 @@ resources:
       bastion_node: {get_attr: [bastion_host, resource.host]}
       dns_servers: {get_param: dns_nameserver}
       dns_update_key: {get_param: dns_update_key}
+      osp_ca_cert: {get_param: osp_ca_cert}
 
 outputs:
 


### PR DESCRIPTION
Originally from @wrichter 
  This version includes updates to all loadbalancer options.

This allows you to enter a trusted ca cert to the openshift nodes and bastion host. This solves the issue https://bugzilla.redhat.com/show_bug.cgi?id=1419182 for me.


To use it, simply add a another parameter to your environment file as such:

trusted_ca_cert: |
-----BEGIN CERTIFICATE-----
<... CERT CONTENT ...>
-----END CERTIFICATE-----