### PR TITLE
Inject OSP CA certificate onto OCP hosts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -276,6 +276,57 @@ Sometimes it's necessary to find out why a stack was not deployed as expected.
 link:README_debugging.adoc[Debugging] helps you find the root cause of the
 issue.
 
+== OpenStack Integration
+
+OpenShift on OpenStack takes advantage of the cloud provider to offer
+features such as dymaic storage to the OpenShift users. Auto scaling
+also requires communication with the OpenStack service.  You must
+provide a set of OpenStack credentials so that OpenShift and the heat
+scaling mechanism can work correctly.
+
+These are the same values used to create the Heat stack.
+
+.Sample OSP Credentials - `osp_credentials.yaml`
+----
+---
+parameters:
+  os_auth_url: http://10.0.x.x:5000/v2.0
+  os_username: <username>
+  os_password: <password>
+  os_region_name: regionOne
+  os_tenant_name: <tenant name>
+----
+
+When invoking the stack creation, include this by adding `-e
+osp_credentials.yaml` to the command.
+
+== [[ca-certificates]]OpenStack with SSL/TLS
+
+If your OpenStack service is encrypted with SSL/TLS, you will need to
+provide the CA certificate so that the communication channel can be
+validated.
+
+The CA certificate is provided as a literal string copy of contents of
+the CA certificate file, and can be included in an additional
+environment file:
+
+.CA Certificate Parameter File `ca_certificates.yaml`
+----
+---
+parameters:
+  ca_cert: |
+    -----BEGIN CERTIFICATE-----
+   ...
+   -----END CERTIFICATE-----
+----
+
+When invoking the stack creation, includ this by adding `-e
+ca_certificates.yaml`.
+
+You can include multiple CA certificate strings and all will be imported
+into the CA list on all instances.
+
+
 == Multiple Master Nodes
 
 You can deploy OpenShift with multiple master hosts using the 'native'
@@ -385,15 +436,15 @@ when you create the stack.
 
 Example of `env_ldap.yaml` using an Active Directory server:
 
-```yaml
+.LDAP parameter file `env_ldap.yaml
+----
 parameter_defaults:
    ldap_hostname: <ldap hostname>
    ldap_ip: <ip of ldap server>
    ldap_url: ldap://<ldap hostname>:389/CN=Users,DC=example,DC=openshift,DC=com?sAMAccountName
    ldap_bind_dn: CN=Administrator,CN=Users,DC=example,DC=openshift,DC=com?sAMAccountName
    ldap_bind_password: <admin password>
-```
-
+----
 
 ```bash
 heat stack-create my-openshift \
@@ -401,6 +452,8 @@ heat stack-create my-openshift \
   -e openshift-on-openstack/env_ldap.yaml \
   -f openshift-on-openstack/openshift.yaml
 ```
+
+If your LDAP service uses SSL, you will also need to add a link:#ca-certificates[CA Certficate] for the LDAP communications.
 
 == Using Custom Yum Repositories
 
@@ -513,7 +566,7 @@ the `dns_nameserver` list.
 You will still need to set the API and wildcard entries, though.
 
 
-== Retrieving the CA certificate
+== Retrieving the OpenShift CA certificate
 
 You can retrieve the CA certificate that was generated during the OpenShift
 installation by running

--- a/bastion.yaml
+++ b/bastion.yaml
@@ -196,6 +196,10 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # A VM to provide host based orchestration and other sub-services
@@ -230,6 +234,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -293,6 +298,15 @@ resources:
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: trusted_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Register the host with RHN for access to software packages
   rhn_register:

--- a/bastion.yaml
+++ b/bastion.yaml
@@ -196,7 +196,7 @@ parameters:
     description: List of docker repository URLs which will be installed on each node, if a repo is insecure use '#insecure' suffix.
     default: ''
 
-  trusted_ca_cert:
+  ca_cert:
     type: string
     description: Certificate Authority Certificate to be added to trust chain
 
@@ -234,7 +234,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
-      - config: {get_resource: ca_cert}
+      - config: {get_resource: update_ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -295,18 +295,17 @@ resources:
         - path: /root/.ssh/id_rsa.pub
           permissions: 0600
           content: {get_param: ansible_public_key}
+        - path: /etc/pki/ca-trust/source/anchors/ca.crt
+          permissions: 0600
+          content: {get_param: ca_cert}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
   # Add CA Cert to trust chain
-  ca_cert:
+  update_ca_cert:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:
-        str_replace:
-          params:
-            $CA_CERT: {get_param: trusted_ca_cert}
-          template: {get_file: fragments/ca_cert.sh}
+      config: {get_file: fragments/ca_cert.sh}
 
   # Register the host with RHN for access to software packages
   rhn_register:

--- a/fragments/ca_cert.sh
+++ b/fragments/ca_cert.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Register with subscription manager and enable required RPM respositories
+#
+# ENVVARS:
+#   CA_CERT - a ca certificate to be added to trust chain
+
+# Exit on command fail
+set -eu
+set -x
+
+# Return the final non-zero exit code of a failed pipe (or 0 for success)
+set -o pipefail
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+if [ -n "$CA_CERT" ] ; then
+    update-ca-trust enable
+    cat >/etc/pki/ca-trust/source/anchors/ca.crt <<EOF
+$CA_CERT
+EOF
+    update-ca-trust extract
+else
+    exit 0
+fi

--- a/fragments/ca_cert.sh
+++ b/fragments/ca_cert.sh
@@ -16,12 +16,9 @@ set -o pipefail
 # MAIN
 # =============================================================================
 
-if [ -n "$CA_CERT" ] ; then
-    update-ca-trust enable
-    cat >/etc/pki/ca-trust/source/anchors/ca.crt <<EOF
-$CA_CERT
-EOF
-    update-ca-trust extract
+if [ -f /etc/pki/ca-trust/source/anchors/ca.crt ] ; then
+  update-ca-trust enable
+  update-ca-trust extract
 else
     exit 0
 fi

--- a/infra.yaml
+++ b/infra.yaml
@@ -228,6 +228,10 @@ parameters:
     type: string
     hidden: true
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # Create a network connection on the internal communications network
@@ -299,6 +303,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -349,6 +354,16 @@ resources:
               template: {get_file: fragments/ifcfg-eth}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: trusted_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Attach to a source of software updates for RHEL
   rhn_register:

--- a/infra.yaml
+++ b/infra.yaml
@@ -228,7 +228,7 @@ parameters:
     type: string
     hidden: true
 
-  trusted_ca_cert:
+  ca_cert:
     type: string
     description: Certificate Authority Certificate to be added to trust chain
 
@@ -303,7 +303,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
-      - config: {get_resource: ca_cert}
+      - config: {get_resource: update_ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -352,18 +352,17 @@ resources:
               params:
                 $IFNAME: eth1
               template: {get_file: fragments/ifcfg-eth}
+        - path: /etc/pki/ca-trust/source/anchors/ca.crt
+          permissions: 0600
+          content: {get_param: ca_cert}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
   # Add CA Cert to trust chain
-  ca_cert:
+  update_ca_cert:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:
-        str_replace:
-          params:
-            $CA_CERT: {get_param: trusted_ca_cert}
-          template: {get_file: fragments/ca_cert.sh}
+      config: {get_file: fragments/ca_cert.sh}
 
   # Attach to a source of software updates for RHEL
   rhn_register:

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -169,7 +169,7 @@ parameters:
     type: string
     hidden: true
 
-  trusted_ca_cert:
+  ca_cert:
     type: string
     description: Certificate Authority Certificate to be added to trust chain
 
@@ -237,7 +237,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
-      - config: {get_resource: ca_cert}
+      - config: {get_resource: update_ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -283,17 +283,20 @@ resources:
               params:
                 $WC_NOTIFY: { get_attr: ['wait_handle', 'curl_cli'] }
               template: {get_file: fragments/common_functions.sh}
+        - path: /etc/pki/ca-trust/source/anchors/ca.crt
+          permissions: 0600
+          content: {get_param: ca_cert}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
   # Add CA Cert to trust chain
-  ca_cert:
+  update_ca_cert:
     type: OS::Heat::SoftwareConfig
     properties:
       config:
         str_replace:
           params:
-            $CA_CERT: {get_param: trusted_ca_cert}
+            $CA_CERT: {get_param: ca_cert}
           template: {get_file: fragments/ca_cert.sh}
 
   # Connect to a software source for updates on RHEL

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -169,6 +169,10 @@ parameters:
     type: string
     hidden: true
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
   floating_ip_assoc:
     type: OS::Neutron::FloatingIPAssociation
@@ -233,6 +237,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -280,6 +285,16 @@ resources:
               template: {get_file: fragments/common_functions.sh}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: trusted_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Connect to a software source for updates on RHEL
   rhn_register:

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -167,6 +167,10 @@ parameters:
     type: string
     hidden: true
 
+  ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 outputs:
   console_url:
     description: URL of the OpenShift web console

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -160,6 +160,10 @@ parameters:
     type: string
     hidden: true
 
+  ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
   lb:
     type: OS::Neutron::LoadBalancer

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -171,6 +171,10 @@ parameters:
     type: string
     hidden: true
 
+  ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 outputs:
   console_url:
     description: URL of the OpenShift web console

--- a/master.yaml
+++ b/master.yaml
@@ -221,7 +221,7 @@ parameters:
     type: string
     hidden: true
 
-  trusted_ca_cert:
+  ca_cert:
     type: string
     description: Certificate Authority Certificate to be added to trust chain
 
@@ -295,7 +295,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
-      - config: {get_resource: ca_cert}
+      - config: {get_resource: update_ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -344,18 +344,17 @@ resources:
               params:
                 $IFNAME: eth1
               template: {get_file: fragments/ifcfg-eth}
+        - path: /etc/pki/ca-trust/source/anchors/ca.crt
+          permissions: 0600
+          content: {get_param: ca_cert}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
   # Add CA Cert to trust chain
-  ca_cert:
+  update_ca_cert:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:
-        str_replace:
-          params:
-            $CA_CERT: {get_param: trusted_ca_cert}
-          template: {get_file: fragments/ca_cert.sh}
+      config: {get_file: fragments/ca_cert.sh}
 
   # Attach to a source of software updates for RHEL
   rhn_register:

--- a/master.yaml
+++ b/master.yaml
@@ -221,6 +221,10 @@ parameters:
     type: string
     hidden: true
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # Create a network connection on the internal communications network
@@ -291,6 +295,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -341,6 +346,16 @@ resources:
               template: {get_file: fragments/ifcfg-eth}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: trusted_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Attach to a source of software updates for RHEL
   rhn_register:

--- a/node.yaml
+++ b/node.yaml
@@ -346,6 +346,10 @@ parameters:
     type: string
     description: Extra parameters for openshift-ansible
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+
 resources:
 
   # Generate a string to distinguish one node from the others
@@ -396,6 +400,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -452,6 +457,16 @@ resources:
               template: {get_file: fragments/ifcfg-eth}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Add CA Cert to trust chain
+  ca_cert:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          params:
+            $CA_CERT: {get_param: trusted_ca_cert}
+          template: {get_file: fragments/ca_cert.sh}
 
   # Connect to software update source for RHEL
   rhn_register:

--- a/node.yaml
+++ b/node.yaml
@@ -346,7 +346,7 @@ parameters:
     type: string
     description: Extra parameters for openshift-ansible
 
-  trusted_ca_cert:
+  ca_cert:
     type: string
     description: Certificate Authority Certificate to be added to trust chain
 
@@ -400,7 +400,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
-      - config: {get_resource: ca_cert}
+      - config: {get_resource: update_ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
       - config: {get_resource: set_extra_docker_repos}
@@ -455,17 +455,20 @@ resources:
               params:
                 $IFNAME: eth1
               template: {get_file: fragments/ifcfg-eth}
+        - path: /etc/pki/ca-trust/source/anchors/ca.crt
+          permissions: 0600
+          content: {get_param: ca_cert}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
   # Add CA Cert to trust chain
-  ca_cert:
+  update_ca_cert:
     type: OS::Heat::SoftwareConfig
     properties:
       config:
         str_replace:
           params:
-            $CA_CERT: {get_param: trusted_ca_cert}
+            $CA_CERT: {get_param: ca_cert}
           template: {get_file: fragments/ca_cert.sh}
 
   # Connect to software update source for RHEL

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -493,7 +493,7 @@ parameters:
     description: Extra parameters for openshift-ansible as a JSON string
     default: ""
 
-  trusted_ca_cert:
+  ca_cert:
     type: string
     description: Certificate Authority Certificate to be added to trust chain
     default: ''
@@ -587,7 +587,7 @@ resources:
       system_update: {get_param: system_update}
       extra_repository_urls: {get_param: extra_repository_urls}
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
-      trusted_ca_cert: {get_param: trusted_ca_cert}
+      ca_cert: {get_param: ca_cert}
 
   openshift_masters:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -631,7 +631,7 @@ resources:
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
           dns_servers: {get_param: dns_nameserver}
           dns_update_key: {get_param: dns_update_key}
-          trusted_ca_cert: {get_param: trusted_ca_cert}
+          ca_cert: {get_param: ca_cert}
 
   openshift_infra_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -676,7 +676,7 @@ resources:
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
           dns_servers: {get_param: dns_nameserver}
           dns_update_key: {get_param: dns_update_key}
-          trusted_ca_cert: {get_param: trusted_ca_cert}
+          ca_cert: {get_param: ca_cert}
 
   openshift_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -753,7 +753,7 @@ resources:
           prepare_ansible: {get_param: prepare_ansible}
           execute_ansible: {get_param: execute_ansible}
           extra_openshift_ansible_params: {get_param: extra_openshift_ansible_params}
-          trusted_ca_cert: {get_param: trusted_ca_cert}
+          ca_cert: {get_param: ca_cert}
 
   # Define the network access policy for openshift nodes
   node_security_group:
@@ -1001,12 +1001,9 @@ resources:
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
       stack_name: {get_param: 'OS::stack_name'}
       bastion_node: {get_attr: [bastion_host, resource.host]}
-<<<<<<< HEAD
       dns_servers: {get_param: dns_nameserver}
       dns_update_key: {get_param: dns_update_key}
-=======
-      trusted_ca_cert: {get_param: trusted_ca_cert}
->>>>>>> aa01b47... add ca config to dedicated loadbalancer
+      ca_cert: {get_param: ca_cert}
 
 outputs:
 

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -493,6 +493,11 @@ parameters:
     description: Extra parameters for openshift-ansible as a JSON string
     default: ""
 
+  trusted_ca_cert:
+    type: string
+    description: Certificate Authority Certificate to be added to trust chain
+    default: ''
+
 resources:
 
   # Network Components
@@ -582,6 +587,7 @@ resources:
       system_update: {get_param: system_update}
       extra_repository_urls: {get_param: extra_repository_urls}
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
+      trusted_ca_cert: {get_param: trusted_ca_cert}
 
   openshift_masters:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -625,6 +631,7 @@ resources:
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
           dns_servers: {get_param: dns_nameserver}
           dns_update_key: {get_param: dns_update_key}
+          trusted_ca_cert: {get_param: trusted_ca_cert}
 
   openshift_infra_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -669,6 +676,7 @@ resources:
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
           dns_servers: {get_param: dns_nameserver}
           dns_update_key: {get_param: dns_update_key}
+          trusted_ca_cert: {get_param: trusted_ca_cert}
 
   openshift_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -745,6 +753,7 @@ resources:
           prepare_ansible: {get_param: prepare_ansible}
           execute_ansible: {get_param: execute_ansible}
           extra_openshift_ansible_params: {get_param: extra_openshift_ansible_params}
+          trusted_ca_cert: {get_param: trusted_ca_cert}
 
   # Define the network access policy for openshift nodes
   node_security_group:
@@ -992,8 +1001,12 @@ resources:
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
       stack_name: {get_param: 'OS::stack_name'}
       bastion_node: {get_attr: [bastion_host, resource.host]}
+<<<<<<< HEAD
       dns_servers: {get_param: dns_nameserver}
       dns_update_key: {get_param: dns_update_key}
+=======
+      trusted_ca_cert: {get_param: trusted_ca_cert}
+>>>>>>> aa01b47... add ca config to dedicated loadbalancer
 
 outputs:
 


### PR DESCRIPTION
Orignally from @wrichter - 

This allows you to enter a trusted ca cert to the openshift nodes and bastion host. This solves the issue https://bugzilla.redhat.com/show_bug.cgi?id=1419182 for me.

To use it, simply add a another parameter to your environment file as such:

trusted_ca_cert: |
-----BEGIN CERTIFICATE-----
<... CERT CONTENT ...>
-----END CERTIFICATE-----