### PR TITLE
add os_domain_name #335

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -295,6 +295,7 @@ parameters:
   os_password: <password>
   os_region_name: regionOne
   os_tenant_name: <tenant name>
+  os_domain_name: <domain name>
 ----
 
 When invoking the stack creation, include this by adding `-e

--- a/fragments/bastion-ansible.sh
+++ b/fragments/bastion-ansible.sh
@@ -48,6 +48,7 @@ function create_metadata_json() {
     "os_auth_url":"$os_auth_url",
     "os_tenant_name":"$os_tenant_name",
     "os_region_name":"$os_region_name",
+    "os_domain_name":"$os_domain_name",
     "dedicated_lb": $([ "$lb_type" == "dedicated" ] && echo true || echo false),
     "no_lb": $([ "$lb_type" == "none" ] && echo true || echo false),
     "external_lb": $([ "$lb_type" == "external" ] && echo true || echo false),

--- a/node.yaml
+++ b/node.yaml
@@ -320,6 +320,13 @@ parameters:
       The name of the OpenStack project or "tenant" for OpenShift to use
     type: string
 
+  os_domain_name:
+    description: >
+      The name of the OpenStack domain for OpenShift to use. Leave it
+      empty for v2 authentication.
+    type: string
+    default: ''
+
   os_region_name:
     description: >
       The name of the OpenStack "region" to use to create or find resources
@@ -711,6 +718,8 @@ resources:
           default: {get_param: os_password}
         - name: os_tenant_name
           default: {get_param: os_tenant_name}
+        - name: os_domain_name
+          default: {get_param: os_domain_name}
         - name: os_region_name
           default: {get_param: os_region_name}
         - name: lb_type

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -453,6 +453,13 @@ parameters:
       The Openstack tenant to by used by Openshift
     default: ''
 
+  os_domain_name:
+    description: >
+      The name of the OpenStack domain for OpenShift to use. Leave it
+      empty for v2 authentication.
+    type: string
+    default: ''
+
   os_region_name:
     type: string
     description: >
@@ -744,6 +751,7 @@ resources:
           os_username: {get_param: os_username}
           os_password: {get_param: os_password}
           os_tenant_name: {get_param: os_tenant_name}
+          os_domain_name: {get_param: os_domain_name}
           os_region_name: {get_param: os_region_name}
           loadbalancer_type: {get_param: loadbalancer_type}
           dns_servers: {get_param: dns_nameserver}

--- a/templates/var/lib/ansible/group_vars/OSv3.yml
+++ b/templates/var/lib/ansible/group_vars/OSv3.yml
@@ -52,6 +52,9 @@ openshift_cloudprovider_openstack_username: {{os_username}}
 openshift_cloudprovider_openstack_password: {{os_password}}
 openshift_cloudprovider_openstack_tenant_name: {{os_tenant_name}}
 openshift_cloudprovider_openstack_region: {{os_region_name}}
+{{#os_domain_name}}
+openshift_cloudprovider_openstack_domain_name: {{os_domain_name}}
+{{/os_domain_name}}
 {{#deploy_registry}}
 openshift_hosted_registry_replicas: 1
 openshift_registry_selector: region=infra


### PR DESCRIPTION
Added support for v3 endpoint and os_domain_name in openstack configuration.

This works smoothly on my RHOSP9 + OCP 3.4