### PR TITLE
added rhel-7-fast-datapath-rpms to repo enable list for OCP3.5+

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -104,9 +104,9 @@ subscription account used for installation.
 |rhel-7-server-rpms | Standard RHEL Server RPMs
 |rhel-7-server-extras-rpms | Supporting RPMs
 |rhel-7-server-optional-rpms | Supporting RPMs
-|rhel-7-server-openstack-8-rpms | OpenStack client and data collection RPMs
-|rhel-7-server-openstack-8-director-rpms | OpenStack data collection RPMs
-|rhel-7-server-ose-3.3-rpms | OpenShift Container Platform RPMs
+|rhel-7-server-openstack-10-rpms | OpenStack client and data collection RPMs
+|rhel-7-server-ose-3.5-rpms | OpenShift Container Platform RPMs
+|rhel-7-fast-datapath-rpms | Required for OSP 3.5+ and OVS 2.6+
 |===
 
 == Creating an All-In-One Demo Environment

--- a/fragments/rhn-register.sh
+++ b/fragments/rhn-register.sh
@@ -84,5 +84,10 @@ retry subscription-manager repos \
                      --enable="rhel-7-server-optional-rpms" \
                      --enable="rhel-7-server-ose-$OCP_VERSION-rpms"
 
+# version 3.5+ require fast-datapath
+if [ $(expr "$OCP_VERSION" \> 3.4) -eq 1 ] ; then
+    retry subscription-manager repos --enable rhel-7-fast-datapath-rpms
+fi
+
 # Allow RPM integrity checking
 rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -9,7 +9,7 @@ parameters:
   # This value is used to select the RPM repo for the OCP release to install
   ocp_version:
     type: string
-    default: "3.4"
+    default: "3.5"
     description: >
       The version of OpenShift Container Platform to deploy
 


### PR DESCRIPTION
This patch updates the default version of OCP to 3.5
It adds the `rhel-7-fast-datapath-rpms` repo to the enabled repo list if the OCP version > 3.4