### PR TITLE
Support for subscription-manager config options #339

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -217,6 +217,7 @@ parameters:
    deploy_registry: False
 
    # If using RHEL image, add RHN credentials for RPM installation on VMs
+   #  and check openshift.yaml for further RHN options
    rhn_username: ""
    rhn_password: ""
    rhn_pool: '' # OPTIONAL

--- a/bastion.yaml
+++ b/bastion.yaml
@@ -80,6 +80,13 @@ parameters:
     type: string
     hidden: true
 
+  rhn_config_options:
+    type: string
+    description: >
+      Further arguments for subscription-manager config, eg. --server.proxy_hostname
+    hidden: true
+    default: ''
+
   # Red Hat satellite subscription parameters
   sat6_hostname:
     type: string
@@ -322,6 +329,7 @@ resources:
             $OCP_VERSION: {get_param: ocp_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
+            $RHN_CONFIG_OPTIONS: {get_param: rhn_config_options}
             $SAT6_HOSTNAME: {get_param: sat6_hostname}
             $SAT6_ORGANIZATION: {get_param: sat6_organization}
             $SAT6_ACTIVATIONKEY: {get_param: sat6_activationkey}

--- a/fragments/rhn-register.sh
+++ b/fragments/rhn-register.sh
@@ -32,6 +32,12 @@ function use_rhn() {
 function register_rhn() {
     # RHN_USERNAME=$1
     # RHN_PASSWORD=$2
+    # RHN_CONFIG_OPTIONS=$3
+
+    if [ -n "$3" ]; then
+        subscription-manager config  $3
+    fi
+
     retry subscription-manager register --username="$1" --password="$2"
 }
 
@@ -60,7 +66,7 @@ if use_satellite6 ; then
     install_sat6_ca_certs $SAT6_HOSTNAME
     register_sat6 $SAT6_ORGANIZATION $SAT6_ACTIVATIONKEY
 elif use_rhn ; then
-    register_rhn $RHN_USERNAME $RHN_PASSWORD
+    register_rhn $RHN_USERNAME $RHN_PASSWORD "$RHN_CONFIG_OPTIONS"
 else
     exit 0
 fi

--- a/infra.yaml
+++ b/infra.yaml
@@ -53,6 +53,13 @@ parameters:
     type: string
     hidden: true
 
+  rhn_config_options:
+    type: string
+    description: >
+      Further arguments for subscription-manager config, eg. --server.proxy_hostname
+    hidden: true
+    default: ''
+
   # Red Hat satellite subscription parameters
   sat6_hostname:
     type: string
@@ -374,6 +381,7 @@ resources:
             $OCP_VERSION: {get_param: ocp_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
+            $RHN_CONFIG_OPTIONS: {get_param: rhn_config_options}
             $SAT6_HOSTNAME: {get_param: sat6_hostname}
             $SAT6_ORGANIZATION: {get_param: sat6_organization}
             $SAT6_ACTIVATIONKEY: {get_param: sat6_activationkey}

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -60,6 +60,13 @@ parameters:
     type: string
     hidden: true
 
+  rhn_config_options:
+    type: string
+    description: >
+      Further arguments for subscription-manager config, eg. --server.proxy_hostname
+    hidden: true
+    default: ''
+
   # Red Hat satellite subscription parameters
   sat6_hostname:
     type: string
@@ -313,6 +320,7 @@ resources:
             $OCP_VERSION: {get_param: ocp_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
+            $RHN_CONFIG_OPTIONS: {get_param: rhn_config_options}
             $SAT6_HOSTNAME: {get_param: sat6_hostname}
             $SAT6_ORGANIZATION: {get_param: sat6_organization}
             $SAT6_ACTIVATIONKEY: {get_param: sat6_activationkey}

--- a/master.yaml
+++ b/master.yaml
@@ -53,6 +53,13 @@ parameters:
     type: string
     hidden: true
 
+  rhn_config_options:
+    type: string
+    description: >
+      Further arguments for subscription-manager config, eg. --server.proxy_hostname
+    hidden: true
+    default: ''
+
   # Red Hat satellite subscription parameters
   sat6_hostname:
     type: string
@@ -366,6 +373,7 @@ resources:
             $OCP_VERSION: {get_param: ocp_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
+            $RHN_CONFIG_OPTIONS: {get_param: rhn_config_options}
             $SAT6_HOSTNAME: {get_param: sat6_hostname}
             $SAT6_ORGANIZATION: {get_param: sat6_organization}
             $SAT6_ACTIVATIONKEY: {get_param: sat6_activationkey}

--- a/node.yaml
+++ b/node.yaml
@@ -72,6 +72,13 @@ parameters:
     type: string
     hidden: true
 
+  rhn_config_options:
+    type: string
+    description: >
+      Further arguments for subscription-manager config, eg. --server.proxy_hostname
+    hidden: true
+    default: ''
+
   # Red Hat satellite subscription parameters
   sat6_hostname:
     type: string
@@ -487,6 +494,7 @@ resources:
             $OCP_VERSION: {get_param: ocp_version}
             $RHN_USERNAME: {get_param: rhn_username}
             $RHN_PASSWORD: {get_param: rhn_password}
+            $RHN_CONFIG_OPTIONS: {get_param: rhn_config_options}
             $SAT6_HOSTNAME: {get_param: sat6_hostname}
             $SAT6_ORGANIZATION: {get_param: sat6_organization}
             $SAT6_ACTIVATIONKEY: {get_param: sat6_activationkey}

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -395,6 +395,13 @@ parameters:
     hidden: true
     default: ''
 
+  rhn_config_options:
+    type: string
+    description: >
+      Further arguments for subscription-manager config, eg. --server.proxy_hostname
+    hidden: true
+    default: ''
+
   # Red Hat satellite subscription parameters
   sat6_hostname:
     type: string
@@ -564,6 +571,7 @@ resources:
       ssh_user: {get_param: ssh_user}
       rhn_username: {get_param: rhn_username}
       rhn_password: {get_param: rhn_password}
+      rhn_config_options: {get_param: rhn_config_options}
       sat6_hostname: {get_param: sat6_hostname}
       sat6_organization: {get_param: sat6_organization}
       sat6_activationkey: {get_param: sat6_activationkey}
@@ -605,6 +613,7 @@ resources:
           ssh_user: {get_param: ssh_user}
           rhn_username: {get_param: rhn_username}
           rhn_password: {get_param: rhn_password}
+          rhn_config_options: {get_param: rhn_config_options}
           sat6_hostname: {get_param: sat6_hostname}
           sat6_organization: {get_param: sat6_organization}
           sat6_activationkey: {get_param: sat6_activationkey}
@@ -649,6 +658,7 @@ resources:
           ssh_user: {get_param: ssh_user}
           rhn_username: {get_param: rhn_username}
           rhn_password: {get_param: rhn_password}
+          rhn_config_options: {get_param: rhn_config_options}
           sat6_hostname: {get_param: sat6_hostname}
           sat6_organization: {get_param: sat6_organization}
           sat6_activationkey: {get_param: sat6_activationkey}
@@ -703,6 +713,7 @@ resources:
           docker_volume_size: {get_param: node_docker_volume_size_gb}
           rhn_username: {get_param: rhn_username}
           rhn_password: {get_param: rhn_password}
+          rhn_config_options: {get_param: rhn_config_options}
           sat6_hostname: {get_param: sat6_hostname}
           sat6_organization: {get_param: sat6_organization}
           sat6_activationkey: {get_param: sat6_activationkey}
@@ -983,6 +994,7 @@ resources:
       ssh_user: {get_param: ssh_user}
       rhn_username: {get_param: rhn_username}
       rhn_password: {get_param: rhn_password}
+      rhn_config_options: {get_param: rhn_config_options}
       sat6_hostname: {get_param: sat6_hostname}
       sat6_organization: {get_param: sat6_organization}
       sat6_activationkey: {get_param: sat6_activationkey}


### PR DESCRIPTION
Added support for `subscription-manager config` options.

Just add to your yaml:

```
...
rhn_user: "joe"
rhn_config_options: "--server.proxy_hostname=proxy.example.com --server.proxy_port=8080"
...
```