### PR TITLE
Timezone support #344.

### DIFF
--- a/bastion.yaml
+++ b/bastion.yaml
@@ -68,6 +68,12 @@ parameters:
       All VMs will be placed in this domain
     type: string
 
+  timezone:
+    description: >
+      The server timezone
+    type: string
+    default: 'Etc/UTC'
+
   # Software Subscription information
   rhn_username:
     description: >
@@ -267,6 +273,7 @@ resources:
     type: OS::Heat::CloudConfig
     properties:
       cloud_config:
+        timezone: {get_param: timezone}
         hostname: {get_param: hostname}
         fqdn:
           str_replace:

--- a/infra.yaml
+++ b/infra.yaml
@@ -92,6 +92,12 @@ parameters:
     - allowed_pattern: '[a-z0-9\-]*'
       description: Hostname must contain only characters [a-z0-9\-].
 
+  timezone:
+    description: >
+      The server timezone
+    type: string
+    default: 'Etc/UTC'
+
   domain_name:
     description: >
       The DNS domain suffix. All VMs will be placed in this domain
@@ -316,6 +322,7 @@ resources:
     type: OS::Heat::CloudConfig
     properties:
       cloud_config:
+        timezone: {get_param: timezone}
         hostname: {get_param: hostname}
         fqdn:
           str_replace:

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -41,6 +41,12 @@ parameters:
     - allowed_pattern: '[a-z0-9\-\.]*'
       description: Hostname must contain only characters [a-z0-9\-\.].
 
+  timezone:
+    description: >
+      The server timezone
+    type: string
+    default: 'Etc/UTC'
+
   domain_name:
     description: >
       All VMs will be placed in this domain
@@ -254,6 +260,7 @@ resources:
     type: OS::Heat::CloudConfig
     properties:
       cloud_config:
+        timezone: {get_param: timezone}
         hostname:
           str_replace:
             template: "%stack_name%-%hostname%"

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -43,6 +43,12 @@ parameters:
     description: Top level stack name.
     type: string
 
+  timezone:
+    description: >
+      The server timezone
+    type: string
+    default: 'Etc/UTC'
+
   domain_name:
     description: >
       All VMs will be placed in this domain

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -42,6 +42,12 @@ parameters:
     description: Top level stack name.
     type: string
 
+  timezone:
+    description: >
+      The server timezone
+    type: string
+    default: 'Etc/UTC'
+
   domain_name:
     description: >
       All VMs will be placed in this domain

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -30,6 +30,12 @@ parameters:
     constraints:
     - custom_constraint: nova.flavor
 
+  timezone:
+    description: >
+      The server timezone
+    type: string
+    default: 'Etc/UTC'
+
   hostname:
     description: >
       The load balancer hostname portion of the FQDN

--- a/master.yaml
+++ b/master.yaml
@@ -92,6 +92,12 @@ parameters:
     - allowed_pattern: '[a-z0-9\-]*'
       description: Hostname must contain only characters [a-z0-9\-].
 
+  timezone:
+    description: >
+      The server timezone
+    type: string
+    default: 'Etc/UTC'
+
   domain_name:
     description: >
       The DNS domain suffix. All VMs will be placed in this domain
@@ -308,6 +314,7 @@ resources:
     type: OS::Heat::CloudConfig
     properties:
       cloud_config:
+        timezone: {get_param: timezone}
         hostname: {get_param: hostname}
         fqdn:
           str_replace:

--- a/node.yaml
+++ b/node.yaml
@@ -109,6 +109,12 @@ parameters:
       unique random substring attached
     type: string
 
+  timezone:
+    description: >
+      The server timezone
+    type: string
+    default: 'Etc/UTC'
+
   domain_name:
     description: >
       The DNS domain suffix. All VMs will be placed in this domain
@@ -419,6 +425,7 @@ resources:
     type: OS::Heat::CloudConfig
     properties:
       cloud_config:
+        timezone: {get_param: timezone}
         hostname:
           str_replace:
             template: "HOST-SUFFIX"

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -208,6 +208,12 @@ parameters:
       Number of non-master nodes to create.
     default: 1
 
+  timezone:
+    description: >
+      The server timezone
+    type: string
+    default: 'Etc/UTC'
+
   # VM Host naming: root domain and host names
   domain_name:
     type: string
@@ -575,6 +581,7 @@ resources:
           params:
             '%stackname%': {get_param: 'OS::stack_name'}
             '%hostname%': {get_param: bastion_hostname}
+      timezone: {get_param: timezone}
       domain_name: {get_param: domain_name}
       fixed_network: {get_resource: fixed_network}
       fixed_subnet: {get_resource: fixed_subnet}
@@ -617,6 +624,7 @@ resources:
               params:
                 '%stackname%': {get_param: 'OS::stack_name'}
                 '%hostname%': {get_param: master_hostname}
+          timezone: {get_param: timezone}
           domain_name: {get_param: domain_name}
           ansible_public_key: {get_attr: [ansible_keys, public_key]}
           bastion_node: {get_attr: [bastion_host, resource.host]}
@@ -661,6 +669,7 @@ resources:
               params:
                 '%stackname%': {get_param: 'OS::stack_name'}
                 '%hostname%': {get_param: infra_hostname}
+          timezone: {get_param: timezone}
           domain_name: {get_param: domain_name}
           ansible_public_key: {get_attr: [ansible_keys, public_key]}
           bastion_node: {get_attr: [bastion_host, resource.host]}
@@ -714,6 +723,7 @@ resources:
               params:
                 '%stackname%': {get_param: 'OS::stack_name'}
                 '%hostname%': {get_param: node_hostname}
+          timezone: {get_param: timezone}
           domain_name: {get_param: domain_name}
           app_subdomain: {get_param: app_subdomain}
           ansible_public_key: {get_attr: [ansible_keys, public_key]}
@@ -989,6 +999,7 @@ resources:
       rhn_pool: {get_param: rhn_pool}
       extra_rhn_pools: {get_param: extra_rhn_pools}
       hostname: {get_param: lb_hostname}
+      timezone: {get_param: timezone}
       domain_name: {get_param: domain_name}
       app_subdomain: {get_param: app_subdomain}
       stack_name: {get_param: 'OS::stack_name'}


### PR DESCRIPTION
Added `timezone` parameter to `openshift.yaml`.

The  default is `Etc/UTC`.

Feedback welcome!