### PR TITLE
A general way to customize all servers #344

### DIFF
--- a/bastion.yaml
+++ b/bastion.yaml
@@ -205,6 +205,12 @@ parameters:
     type: string
     description: Certificate Authority Certificate to be added to trust chain
 
+  host_config:
+    type: string
+    description: >
+      An OS::Heat::MultiPartMime containing CloudConfig objects.
+    default: ''
+
 resources:
 
   # A VM to provide host based orchestration and other sub-services
@@ -237,6 +243,8 @@ resources:
     type: OS::Heat::MultipartMime
     properties:
       parts:
+      - config: {get_param: host_config}
+        type: multipart
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
       - config: {get_resource: update_ca_cert}

--- a/infra.yaml
+++ b/infra.yaml
@@ -232,6 +232,12 @@ parameters:
     type: string
     description: Certificate Authority Certificate to be added to trust chain
 
+  host_config:
+    type: string
+    description: >
+      An OS::Heat::MultiPartMime containing CloudConfig objects.
+    default: ''
+
 resources:
 
   # Create a network connection on the internal communications network
@@ -301,6 +307,8 @@ resources:
     type: OS::Heat::MultipartMime
     properties:
       parts:
+      - config: {get_param: host_config}
+        type: multipart
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
       - config: {get_resource: update_ca_cert}

--- a/master.yaml
+++ b/master.yaml
@@ -225,6 +225,12 @@ parameters:
     type: string
     description: Certificate Authority Certificate to be added to trust chain
 
+  host_config:
+    type: string
+    description: >
+      An OS::Heat::MultiPartMime containing CloudConfig objects.
+    default: ''
+
 resources:
 
   # Create a network connection on the internal communications network
@@ -293,6 +299,8 @@ resources:
     type: OS::Heat::MultipartMime
     properties:
       parts:
+      - config: {get_param: host_config}
+        type: multipart
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
       - config: {get_resource: update_ca_cert}

--- a/node.yaml
+++ b/node.yaml
@@ -363,6 +363,12 @@ parameters:
     type: string
     description: Certificate Authority Certificate to be added to trust chain
 
+  host_config:
+    type: string
+    description: >
+      An OS::Heat::MultiPartMime containing CloudConfig objects.
+    default: ''
+
 resources:
 
   # Generate a string to distinguish one node from the others
@@ -411,6 +417,8 @@ resources:
     type: OS::Heat::MultipartMime
     properties:
       parts:
+      - config: {get_param: host_config}
+        type: multipart
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
       - config: {get_resource: update_ca_cert}

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -507,6 +507,21 @@ parameters:
 
 resources:
 
+  # Common host configs
+  common_cloud_config:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        timezone: Europe/Rome
+
+  # This multipart will be applied to
+  #   all the openshift hosts.
+  common_config:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+      - config: {get_resource: common_cloud_config}
+
   # Network Components
   fixed_network:
     type: OS::Neutron::Net
@@ -596,6 +611,7 @@ resources:
       extra_repository_urls: {get_param: extra_repository_urls}
       extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
       ca_cert: {get_param: ca_cert}
+      host_config: {get_resource: common_config}
 
   openshift_masters:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -640,6 +656,7 @@ resources:
           dns_servers: {get_param: dns_nameserver}
           dns_update_key: {get_param: dns_update_key}
           ca_cert: {get_param: ca_cert}
+          host_config: {get_resource: common_config}
 
   openshift_infra_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -685,6 +702,7 @@ resources:
           dns_servers: {get_param: dns_nameserver}
           dns_update_key: {get_param: dns_update_key}
           ca_cert: {get_param: ca_cert}
+          host_config: {get_resource: common_config}
 
   openshift_nodes:
     depends_on: [external_router_interface, fixed_network, fixed_subnet]
@@ -764,6 +782,7 @@ resources:
           execute_ansible: {get_param: execute_ansible}
           extra_openshift_ansible_params: {get_param: extra_openshift_ansible_params}
           ca_cert: {get_param: ca_cert}
+          host_config: {get_resource: common_config}
 
   # Define the network access policy for openshift nodes
   node_security_group:


### PR DESCRIPTION
A general way to configure openshift vm in a single place.

  - Define an OS::Heat::MultipartMime in openshift.yaml 
  - Pass it to all hosts

For now it just contains a Timezone definition. We can put `subscription-manager` and other stuff there.

Feedback welcome