### PR TITLE
updated heat_template_version to 2016-10-14

### DIFF
--- a/bastion.yaml
+++ b/bastion.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 
 description: >

--- a/collect-config-setup/install_config_agent_centos_yum.yaml
+++ b/collect-config-setup/install_config_agent_centos_yum.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 parameters:
 

--- a/infra.yaml
+++ b/infra.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 
 description: >

--- a/ipfailover_keepalived.yaml
+++ b/ipfailover_keepalived.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which deploys a IP failover service for the Openshift router

--- a/ipfailover_none.yaml
+++ b/ipfailover_none.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which deploys a IP failover service for the Openshift router

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which provides a creates a loadbalancer using neutron's LBaaS.

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which doesn't create any resources supposing that an external

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which provides a creates a loadbalancer using neutron's LBaaS.

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which provides a creates a loadbalancer using neutron's LBaaS.

--- a/master.yaml
+++ b/master.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 
 description: >

--- a/node.yaml
+++ b/node.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 
 description: >

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   Deploy Atomic/OpenShift 3 on OpenStack.

--- a/registry_ephemeral.yaml
+++ b/registry_ephemeral.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which creates a cinder volume used by openshift registry,

--- a/registry_persistent.yaml
+++ b/registry_persistent.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which allows usage of an existing cinder volume as a persistent

--- a/sdn_flannel.yaml
+++ b/sdn_flannel.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which creates a dedicated network for container communication

--- a/sdn_openshift_sdn.yaml
+++ b/sdn_openshift_sdn.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which provides a creates a dedicated network for container communication

--- a/volume_attachment_docker.yaml
+++ b/volume_attachment_docker.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which provides a volume for Docker storage

--- a/volume_attachment_noop.yaml
+++ b/volume_attachment_noop.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which provides a volume for Docker storage

--- a/volume_docker.yaml
+++ b/volume_docker.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which provides a volume for Docker storage

--- a/volume_noop.yaml
+++ b/volume_noop.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   A template which provides a volume for Docker storage


### PR DESCRIPTION
The heat templates need to use Gnocchi updates which became available in 2015.  The current template version tag is 2014-10-16

The heat_template_version has been updated to 2016-10-14 and re-run with no change in behavior.