### PR TITLE
remove Fn::Select

### DIFF
--- a/openshift.yaml
+++ b/openshift.yaml
@@ -1054,11 +1054,11 @@ outputs:
 
   ca_cert:
     description: Openshift CA certificate.
-    value: {"Fn::Select": ["0", {get_attr: [openshift_nodes, outputs_list, ca_cert]}]}
+    value: {get_attr: [openshift_nodes, ca_cert]}
 
   ca_key:
     description: Openshift CA certificate key.
-    value: {"Fn::Select": ["0", {get_attr: [openshift_nodes, outputs_list, ca_key]}]}
+    value: {get_attr: [openshift_nodes, ca_key]}
 
   master_ips:
     description: List of openshift master node IPs


### PR DESCRIPTION
The Fn::Select function in HOT  2014-10-14 is no longer available in 2016-10-14.  The get_attr function has been updated to allow access directly to resource outputs by name.

This PR replaces the Fn::Select calls in openshift.yaml.