### PR TITLE
converted Ceilometer alarms to gnocchi

### DIFF
--- a/bastion.yaml
+++ b/bastion.yaml
@@ -311,7 +311,7 @@ resources:
   disable_ipv6:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:{get_file: fragments/disable_ipv6.sh}
+      config: {get_file: fragments/disable_ipv6.sh}
 
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/bastion.yaml
+++ b/bastion.yaml
@@ -239,6 +239,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: disable_ipv6}
       - config: {get_resource: update_ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
@@ -305,6 +306,12 @@ resources:
           content: {get_param: ca_cert}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Disable IPv6 in the kernel
+  disable_ipv6:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:{get_file: fragments/disable_ipv6.sh
 
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/bastion.yaml
+++ b/bastion.yaml
@@ -311,7 +311,7 @@ resources:
   disable_ipv6:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:{get_file: fragments/disable_ipv6.sh
+      config:{get_file: fragments/disable_ipv6.sh}
 
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/fragments/disable_ipv6.sh
+++ b/fragments/disable_ipv6.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Disable IPv6 system wide and permanently
+#
+# Live
+sysctl -w net.ipv6.conf.eth0.disable_ipv6=1
+
+# Permanently
+cat > /etc/sysctl.d/10-disable-ipv6.conf <<EOF
+net.ipv6.conf.eth0.disable_ipv6=1
+EOF

--- a/infra.yaml
+++ b/infra.yaml
@@ -363,7 +363,7 @@ resources:
   disable_ipv6:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:{get_file: fragments/disable_ipv6.sh
+      config:{get_file: fragments/disable_ipv6.sh}
     
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/infra.yaml
+++ b/infra.yaml
@@ -363,7 +363,7 @@ resources:
   disable_ipv6:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:{get_file: fragments/disable_ipv6.sh}
+      config: {get_file: fragments/disable_ipv6.sh}
     
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/infra.yaml
+++ b/infra.yaml
@@ -303,6 +303,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: disable_ipv6}
       - config: {get_resource: update_ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
@@ -358,6 +359,12 @@ resources:
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
+  # Disable IPv6 in the kernel
+  disable_ipv6:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:{get_file: fragments/disable_ipv6.sh
+    
   # Add CA Cert to trust chain
   update_ca_cert:
     type: OS::Heat::SoftwareConfig

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -240,6 +240,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: disable_ipv6}
       - config: {get_resource: update_ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
@@ -292,6 +293,12 @@ resources:
           content: {get_param: ca_cert}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Disable IPv6 in the kernel
+  disable_ipv6:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:{get_file: fragments/disable_ipv6.sh}
 
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -298,7 +298,7 @@ resources:
   disable_ipv6:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:{get_file: fragments/disable_ipv6.sh}
+      config: {get_file: fragments/disable_ipv6.sh}
 
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/master.yaml
+++ b/master.yaml
@@ -295,6 +295,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: disable_ipv6}
       - config: {get_resource: update_ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
@@ -350,6 +351,12 @@ resources:
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
 
+  # Disable IPv6 in the kernel
+  disable_ipv6:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:{get_file: fragments/disable_ipv6.sh
+  
   # Add CA Cert to trust chain
   update_ca_cert:
     type: OS::Heat::SoftwareConfig

--- a/master.yaml
+++ b/master.yaml
@@ -355,7 +355,7 @@ resources:
   disable_ipv6:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:{get_file: fragments/disable_ipv6.sh}
+      config: {get_file: fragments/disable_ipv6.sh}
   
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/master.yaml
+++ b/master.yaml
@@ -355,7 +355,7 @@ resources:
   disable_ipv6:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:{get_file: fragments/disable_ipv6.sh
+      config:{get_file: fragments/disable_ipv6.sh}
   
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/node.yaml
+++ b/node.yaml
@@ -479,7 +479,7 @@ resources:
   disable_ipv6:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:{get_file: fragments/disable_ipv6.sh
+      config:{get_file: fragments/disable_ipv6.sh}
 
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/node.yaml
+++ b/node.yaml
@@ -479,7 +479,7 @@ resources:
   disable_ipv6:
     type: OS::Heat::SoftwareConfig
     properties:
-      config:{get_file: fragments/disable_ipv6.sh}
+      config: {get_file: fragments/disable_ipv6.sh}
 
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/node.yaml
+++ b/node.yaml
@@ -413,6 +413,7 @@ resources:
       parts:
       - config: {get_resource: set_hostname}
       - config: {get_resource: included_files}
+      - config: {get_resource: disable_ipv6}
       - config: {get_resource: update_ca_cert}
       - config: {get_resource: rhn_register}
       - config: {get_resource: set_extra_repos}
@@ -473,6 +474,12 @@ resources:
           content: {get_param: ca_cert}
         ssh_authorized_keys:
         - {get_param: ansible_public_key}
+
+  # Disable IPv6 in the kernel
+  disable_ipv6:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:{get_file: fragments/disable_ipv6.sh
 
   # Add CA Cert to trust chain
   update_ca_cert:

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -801,33 +801,44 @@ resources:
       cooldown: 60
       scaling_adjustment: '-1'
 
+
   cpu_alarm_high:
-    type: OS::Ceilometer::Alarm
+    type: OS::Ceilometer::GnocchiAggregationByResourcesAlarm
+    description : Increase the number of slaves when all of them are loaded
     properties:
-      meter_name: cpu_util
-      statistic: avg
-      period: 60
-      evaluation_periods: 1
+      metric: cpu_util
+      comparison_operator: gt
       threshold: 50
-      enabled: {get_param: autoscaling}
+      granularity: 300
+      evaluation_periods: 1
+      aggregation_method: last
+      resource_type: instance
       alarm_actions:
         - {get_attr: [scale_up_policy, alarm_url]}
-      matching_metadata: {'metadata.user_metadata.stack': {get_param: "OS::stack_id"}}
-      comparison_operator: gt
+      query:
+        str_replace:
+          template: '{"=": {"server_group": "stack_id"}}'
+          params:
+            stack_id: {get_param: "OS::stack_id"}
 
   cpu_alarm_low:
-    type: OS::Ceilometer::Alarm
+    type: OS::Ceilometer::GnocchiAggregationByResourcesAlarm
+    description : Increase the number of slaves when all of them are loaded
     properties:
-      meter_name: cpu_util
-      statistic: avg
-      period: 600
-      evaluation_periods: 1
-      threshold: 15
-      enabled: {get_param: autoscaling}
-      alarm_actions:
-        - {get_attr: [scale_down_policy, alarm_url]}
-      matching_metadata: {'metadata.user_metadata.stack': {get_param: "OS::stack_id"}}
+      metric: cpu_util
       comparison_operator: lt
+      threshold: 15
+      granularity: 300
+      evaluation_periods: 1
+      aggregation_method: last
+      resource_type: instance
+      alarm_actions:
+        - {get_attr: [scale_up_policy, alarm_url]}
+      query:
+        str_replace:
+          template: '{"=": {"server_group": "stack_id"}}'
+          params:
+            stack_id: {get_param: "OS::stack_id"}
 
   bastion_port:
     type: OS::Neutron::Port
@@ -1054,11 +1065,11 @@ outputs:
 
   ca_cert:
     description: Openshift CA certificate.
-    value: {"Fn::Select": ["0", {get_attr: [openshift_nodes, outputs_list, ca_cert]}]}
+    value: {get_attr: [openshift_nodes, ca_cert]}
 
   ca_key:
     description: Openshift CA certificate key.
-    value: {"Fn::Select": ["0", {get_attr: [openshift_nodes, outputs_list, ca_key]}]}
+    value: {get_attr: [openshift_nodes, ca_key]}
 
   master_ips:
     description: List of openshift master node IPs

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -803,7 +803,7 @@ resources:
 
 
   cpu_alarm_high:
-    type: OS::Ceilometer::GnocchiAggregationByResourcesAlarm
+    type: OS::Aodh::GnocchiAggregationByResourcesAlarm
     description : Increase the number of slaves when all of them are loaded
     properties:
       metric: cpu_util
@@ -811,18 +811,20 @@ resources:
       threshold: 50
       granularity: 300
       evaluation_periods: 1
-      aggregation_method: last
+      aggregation_method: mean
       resource_type: instance
       alarm_actions:
-        - {get_attr: [scale_up_policy, alarm_url]}
+        - str_replace:
+            template: trust+url
+            params:
+              url: {get_attr: [scale_up_policy, signal_url]}
       query:
-        str_replace:
-          template: '{"=": {"server_group": "stack_id"}}'
-          params:
-            stack_id: {get_param: "OS::stack_id"}
+        list_join:
+          - ''
+          - - {'=': {server_group: {get_param: "OS::stack_id"}}}
 
   cpu_alarm_low:
-    type: OS::Ceilometer::GnocchiAggregationByResourcesAlarm
+    type: OS::Aodh::GnocchiAggregationByResourcesAlarm
     description : Increase the number of slaves when all of them are loaded
     properties:
       metric: cpu_util
@@ -830,15 +832,17 @@ resources:
       threshold: 15
       granularity: 300
       evaluation_periods: 1
-      aggregation_method: last
+      aggregation_method: mean
       resource_type: instance
       alarm_actions:
-        - {get_attr: [scale_up_policy, alarm_url]}
+        - str_replace:
+            template: trust+url
+            params:
+              url: {get_attr: [scale_down_policy, signal_url]}
       query:
-        str_replace:
-          template: '{"=": {"server_group": "stack_id"}}'
-          params:
-            stack_id: {get_param: "OS::stack_id"}
+        list_join:
+          - ''
+          - - {'=': {server_group: {get_param: "OS::stack_id"}}}
 
   bastion_port:
     type: OS::Neutron::Port


### PR DESCRIPTION
converted Ceilometer alarms to gnocchi

removed deprecated Fn::Select and replaced with path based get_attr