### PR TITLE
return default ocp version to 3.4

### DIFF
--- a/openshift.yaml
+++ b/openshift.yaml
@@ -9,7 +9,7 @@ parameters:
   # This value is used to select the RPM repo for the OCP release to install
   ocp_version:
     type: string
-    default: "3.5"
+    default: "3.4"
     description: >
       The version of OpenShift Container Platform to deploy
 


### PR DESCRIPTION
The default OCP version should be 3.4, not 3.5 until approved.