### PR TITLE
fix #370: run deployment_bastion_node_cleanup only on the same server uuid

### DIFF
--- a/fragments/bastion-node-cleanup.sh
+++ b/fragments/bastion-node-cleanup.sh
@@ -20,7 +20,7 @@ if [ -e $INVENTORY -a "$node_type" == node ]; then
     export ANSIBLE_ROLES_PATH=/usr/share/ansible/openshift-ansible/roles
     export ANSIBLE_HOST_KEY_CHECKING=False
 
-    ansible-playbook -vvvv -e node=$node_name \
+    ansible-playbook -vvvv -e node=$node_name -e node_id=$node_id \
         --inventory /var/lib/ansible/inventory \
         /var/lib/ansible/playbooks/scaledown.yml &>> /var/log/ansible-scaledown.$$ || true
 fi
@@ -32,9 +32,15 @@ if [ -e $NODESFILE ]; then
     grep -v "$node_name" ${NODESFILE}.bkp > $NODESFILE || true
 fi
 
-# unregister the node if registered with subscription-manager
-[ -e $INVENTORY ] && ansible $node_name -m shell \
+# unregister the node if 
+# - node_id matches the one defined in deployment_bastion_node_cleanup
+# - registered with subscription-manager
+if [ -e $INVENTORY ]; then
+    echo "Cleanup node $node_name with $node_id" >> /var/log/ansible-node-cleanup.log
+    ansible $node_name -m shell \
         -u $ssh_user --sudo -i $INVENTORY \
-        -a "subscription-manager unregister && subscription-manager clean" || true
+        -a "test -d /var/lib/cloud/instances/$node_id && subscription-manager unregister && subscription-manager clean" || true
+fi
 
-echo "Deleted node $node_name"
+
+echo "Deleted node $node_name with id $node_id"

--- a/infra.yaml
+++ b/infra.yaml
@@ -485,6 +485,7 @@ resources:
     properties:
       group: script
       inputs:
+      - name: node_id
       - name: node_name
       - name: node_type
       - name: ssh_user
@@ -501,6 +502,7 @@ resources:
     properties:
       actions: ['DELETE']
       input_values:
+        node_id: {get_resource: host}
         node_type: infra
         node_name:
           str_replace:

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -395,6 +395,7 @@ resources:
     properties:
       group: script
       inputs:
+      - name: node_id
       - name: node_name
       - name: node_type
       - name: ssh_user
@@ -411,6 +412,7 @@ resources:
     properties:
       actions: ['DELETE']
       input_values:
+        node_id: {get_resource: host}
         node_type: loadbalancer
         node_name:
           str_replace:

--- a/master.yaml
+++ b/master.yaml
@@ -477,6 +477,7 @@ resources:
     properties:
       group: script
       inputs:
+      - name: node_id
       - name: node_name
       - name: node_type
       - name: ssh_user
@@ -493,6 +494,7 @@ resources:
     properties:
       actions: ['DELETE']
       input_values:
+        node_id: {get_resource: host}
         node_type: master
         node_name:
           str_replace:

--- a/node.yaml
+++ b/node.yaml
@@ -587,6 +587,7 @@ resources:
     properties:
       group: script
       inputs:
+      - name: node_id
       - name: node_name
       - name: node_type
       - name: ssh_user
@@ -603,6 +604,7 @@ resources:
     properties:
       actions: ['DELETE']
       input_values:
+        node_id: {get_resource: host}
         node_type: node
         node_name:
           str_replace:


### PR DESCRIPTION
This patch should fix the very annoying #370 

Before unregistering the node it checks if the server uuid attached to the OS::Heat::DeploymentConfig is the same of the target machine.

As the ip address could be reused in time (eg. if the server is removed instead of just marked unhealthy) I used the server uuid, relying on

```
/var/lib/cloud/instances/$node_id 
```

Feedback welcome + Peace,
R: