### PR TITLE
remove unused code from pre-DNS

### DIFF
--- a/infra.yaml
+++ b/infra.yaml
@@ -448,7 +448,6 @@ resources:
     properties:
       group: script
       inputs:
-      - name: node_etc_host
       - name: node_hostname
       - name: node_type
       outputs:
@@ -472,13 +471,6 @@ resources:
             params:
               HOST: {get_param: hostname}
               DOMAIN: {get_param: domain_name}
-        node_etc_host:
-          str_replace:
-              template: "IP HOST.DOMAIN HOST #openshift"
-              params:
-                IP: {get_attr: [port, fixed_ips, 0, ip_address]}
-                HOST: {get_param: hostname}
-                DOMAIN: {get_param: domain_name}
 
   node_cleanup:
     type: OS::Heat::SoftwareConfig

--- a/master.yaml
+++ b/master.yaml
@@ -440,7 +440,6 @@ resources:
     properties:
       group: script
       inputs:
-      - name: node_etc_host
       - name: node_hostname
       - name: node_type
       outputs:
@@ -464,13 +463,6 @@ resources:
             params:
               HOST: {get_param: hostname}
               DOMAIN: {get_param: domain_name}
-        node_etc_host:
-          str_replace:
-              template: "IP HOST.DOMAIN HOST #openshift"
-              params:
-                IP: {get_attr: [port, fixed_ips, 0, ip_address]}
-                HOST: {get_param: hostname}
-                DOMAIN: {get_param: domain_name}
 
   node_cleanup:
     type: OS::Heat::SoftwareConfig

--- a/node.yaml
+++ b/node.yaml
@@ -622,7 +622,6 @@ resources:
     properties:
       group: script
       inputs:
-      - name: node_etc_host
       - name: node_hostname
       - name: node_type
       outputs:
@@ -647,14 +646,6 @@ resources:
               HOST: {get_param: hostname}
               SUFFIX: {get_attr: [random_hostname_suffix, value]}
               DOMAIN: {get_param: domain_name}
-        node_etc_host:
-          str_replace:
-              template: "IP HOST-SUFFIX.DOMAIN HOST-SUFFIX #openshift"
-              params:
-                IP: {get_attr: [port, fixed_ips, 0, ip_address]}
-                HOST: {get_param: hostname}
-                SUFFIX: {get_attr: [random_hostname_suffix, value]}
-                DOMAIN: {get_param: domain_name}
 
   # Execute the ansible playbook(s) on the bastion server to configure the
   # openshift hosts and services


### PR DESCRIPTION
This patch removes code that is no longer used.  It was used to generate an entry for each instance in the /etc/hosts file on the bastion.  The dynamic DNS service makes this unnecessary and in some cases this code causes the stack to fail