### PR TITLE
remove dot after hostname

### DIFF
--- a/fragments/add_dns_record.sh
+++ b/fragments/add_dns_record.sh
@@ -26,5 +26,4 @@ if [ -n "$NAME" -a "${NAME:0:1}" = "%" -a "${NAME: -1}" = "%" ]; then
     NAME="$(hostname)"
 fi
 
-# NOTE: the dot after the hostname is necessary
-/usr/local/bin/update_dns -z "%ZONE%" -s "%DNS_SERVER%" -k "$DNS_UPDATE_KEY" "$NAME." "%IP_ADDRESS%"
+/usr/local/bin/update_dns -z "%ZONE%" -s "%DNS_SERVER%" -k "$DNS_UPDATE_KEY" "$NAME" "%IP_ADDRESS%"

--- a/fragments/add_dns_record.sh
+++ b/fragments/add_dns_record.sh
@@ -23,7 +23,7 @@ NAME="%DNS_ENTRY%"
 
 # If we didn't get an explicit name, use this server's hostname
 if [ -n "$NAME" -a "${NAME:0:1}" = "%" -a "${NAME: -1}" = "%" ]; then
-    NAME="$(hostname)"
+    NAME="$(hostname -s)"
 fi
 
 /usr/local/bin/update_dns -z "%ZONE%" -s "%DNS_SERVER%" -k "$DNS_UPDATE_KEY" "$NAME" "%IP_ADDRESS%"

--- a/fragments/add_dns_record.sh
+++ b/fragments/add_dns_record.sh
@@ -24,6 +24,8 @@ NAME="%DNS_ENTRY%"
 # If we didn't get an explicit name, use this server's hostname
 if [ -n "$NAME" -a "${NAME:0:1}" = "%" -a "${NAME: -1}" = "%" ]; then
     NAME="$(hostname -s)"
+else
+    NAME="$NAME."
 fi
 
 /usr/local/bin/update_dns -z "%ZONE%" -s "%DNS_SERVER%" -k "$DNS_UPDATE_KEY" "$NAME" "%IP_ADDRESS%"


### PR DESCRIPTION
When dot is at the end of hostname, when we get : 
ERROR: update failed: NOTZONE