### PR TITLE
fix: registry_ephemeral creates persistent volume #358

### DIFF
--- a/registry_ephemeral.yaml
+++ b/registry_ephemeral.yaml
@@ -16,13 +16,8 @@ parameters:
       Size of the Openshift registry persistent volume
     type: number
 
-resources:
-  volume:
-    type: OS::Cinder::Volume
-    properties:
-      size: {get_param: volume_size}
 
 outputs:
   volume_id:
     description: cinder volume id
-    value: {get_resource: volume}
+    value: {get_param: volume_id}


### PR DESCRIPTION
Registry ephemeral is not supposed to create a persistent volume.