### PR TITLE
#379 support single nic

### DIFF
--- a/fragments/infra-boot.sh
+++ b/fragments/infra-boot.sh
@@ -18,7 +18,8 @@ source /usr/local/share/openshift-on-openstack/common_functions.sh
 source /usr/local/share/openshift-on-openstack/common_openshift_functions.sh
 
 
-ifup eth1
+# Setup eth1 only if it's present
+grep eth1 /proc/net/dev && ifup eth1
 
 sudo_set_secure_path "/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin"
 sudo_enable_from_ssh

--- a/fragments/master-boot.sh
+++ b/fragments/master-boot.sh
@@ -21,8 +21,8 @@ set -o pipefail
 source /usr/local/share/openshift-on-openstack/common_functions.sh
 source /usr/local/share/openshift-on-openstack/common_openshift_functions.sh
 
-
-ifup eth1
+# Setup eth1 only if it's present
+grep eth1 /proc/net/dev && ifup eth1
 
 sudo_set_secure_path "/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin"
 sudo_enable_from_ssh

--- a/fragments/node-boot.sh
+++ b/fragments/node-boot.sh
@@ -18,7 +18,8 @@ source /usr/local/share/openshift-on-openstack/common_functions.sh
 source /usr/local/share/openshift-on-openstack/common_openshift_functions.sh
 
 
-ifup eth1
+# Setup eth1 only if it's present
+grep eth1 /proc/net/dev && ifup eth1
 
 sudo_set_secure_path "/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin"
 sudo_enable_from_ssh


### PR DESCRIPTION
## Reproduce

OCP has the following issue with non-flannel multi-nic deployments
https://trello.com/c/9uWhXxJP/875-5-fix-openshift-sdn-host-subnet-assignment-with-multiple-interfaces-on-instances 

## This PR

Allows to comment the second interface in deployment and still have working scripts.