### PR TITLE
DNS dynamic update improvement

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -199,6 +199,11 @@ parameters:
    external_network: public
    dns_nameserver: 8.8.4.4,8.8.8.8
 
+   # Optionnaly set dynamic DNS update
+   #dns_update_master="ns1.example.com"
+   #dns_update_keyname="update-key"
+   #dns_update_key="Bf/sev4534fdfv...="
+
    # Define the host name templates for master and nodes
    domain_name: "example.com"
    master_hostname: "origin-master"
@@ -560,9 +565,10 @@ domain used in OpenShift cluster (`example.com` in the example above).
 === Dynamic DNS Updates
 
 If your DNS servers support dynamic updates (as defined in RFC 2136),
-you can pass the update key in the `dns_update_key` parameter and each
-node will register its internal IP address to all the DNS servers in
-the `dns_nameserver` list.
+you can pass the update key name in the `dns_update_keyname` (default to 
+`update-key`), and the key value in the `dns_update_key` parameter, and each
+node will register its internal IP address to the `dns_update_master` (default
+to first of `dns_servers`) DNS server.
 
 In addition, if you use the *dedicated load balancer*, the API and
 wildcard entries will be created as well. Otherwise, you will need to

--- a/fragments/add_dns_record.sh
+++ b/fragments/add_dns_record.sh
@@ -6,10 +6,15 @@ set -x
 set -o pipefail
 
 DNS_UPDATE_KEY="%DNS_UPDATE_KEY%"
+DNS_UPDATE_KEYNAME="%DNS_UPDATE_KEYNAME%"
 
 if [ -z "$DNS_UPDATE_KEY" ]; then
     echo "Skipping the DNS update because the key is empty."
     exit
+fi
+
+if [ -z "$DNS_UPDATE_KEYNAME" ]; then
+    export DNS_UPDATE_KEYNAME='update-key'
 fi
 
 if yum info python-dns; then
@@ -27,4 +32,4 @@ if [ -n "$NAME" -a "${NAME:0:1}" = "%" -a "${NAME: -1}" = "%" ]; then
 fi
 
 # NOTE: the dot after the hostname is necessary
-/usr/local/bin/update_dns -z "%ZONE%" -s "%DNS_SERVER%" -k "$DNS_UPDATE_KEY" "$NAME." "%IP_ADDRESS%"
+/usr/local/bin/update_dns -z "%ZONE%" -s "%DNS_UPDATE_MASTER%" -n "$DNS_UPDATE_KEYNAME" -k "$DNS_UPDATE_KEY" "$NAME." "%IP_ADDRESS%"

--- a/fragments/update_dns.py
+++ b/fragments/update_dns.py
@@ -15,11 +15,11 @@ import dns.update
 import dns.rcode
 
 
-def add_a_record(server, zone, key, name, address, ttl=300):
+def add_a_record(server, zone, keyname, key, name, address, ttl=300):
 
     # make input zones absolute
     #zone = zone + '.' if not zone.endswith('.')
-    keyring = dns.tsigkeyring.from_text({'update-key': key})
+    keyring = dns.tsigkeyring.from_text({keyname: key})
     update = dns.update.Update(zone, keyring=keyring)
     update.replace(name, ttl, 'a', address)
     response = dns.query.tcp(update, server)
@@ -33,13 +33,14 @@ if __name__ == "__main__":
         parser.add_argument("-s", "--server", type=str, default="127.0.0.1")
         parser.add_argument("-z", "--zone", type=str, default="example.com")
         parser.add_argument("-k", "--key", type=str, default=os.getenv("DNS_KEY"))
+        parser.add_argument("-n", "--keyname", type=str, default=os.getenv("DNS_KEYNAME"))
         parser.add_argument("name", type=str)
         parser.add_argument("address", type=str)
         parser.add_argument("-t", "--ttl", type=str, default=300)
         return parser.parse_args()
 
     opts = process_arguments()
-    r = add_a_record(opts.server, opts.zone, opts.key, opts.name, opts.address, opts.ttl)
+    r = add_a_record(opts.server, opts.zone, opts.keyname, opts.key, opts.name, opts.address, opts.ttl)
 
     if r.rcode() != dns.rcode.NOERROR:
         print("ERROR: update failed: {}".format(dns.rcode.to_text(r.rcode())))

--- a/infra.yaml
+++ b/infra.yaml
@@ -224,6 +224,16 @@ parameters:
     type: comma_delimited_list
     description: address of dns nameservers reachable in your environment
 
+  dns_update_master:
+    type: string
+    description: >
+      The DNS server to use for dns updates (can be an hidden master)
+
+  dns_update_keyname:
+    type: string
+    description: >
+      Name of the DNS key to use
+
   dns_update_key:
     type: string
     hidden: true
@@ -427,7 +437,8 @@ resources:
         str_replace:
           params:
             '%ZONE%': {get_param: domain_name}
-            '%DNS_SERVER%': {get_param: [dns_servers, 0]}
+            '%DNS_UPDATE_MASTER%': {get_param: dns_update_master}
+            '%DNS_UPDATE_KEYNAME%': {get_param: dns_update_keyname}
             '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
             '%IP_ADDRESS%': {get_attr: [port, fixed_ips, 0, ip_address]}
           template: {get_file: fragments/add_dns_record.sh}

--- a/loadbalancer_dedicated.yaml
+++ b/loadbalancer_dedicated.yaml
@@ -168,6 +168,14 @@ parameters:
     type: comma_delimited_list
     description: address of dns nameservers reachable in your environment
 
+  dns_update_master:
+    type: string
+    hidden: true
+
+  dns_update_keyname:
+    type: string
+    hidden: true
+
   dns_update_key:
     type: string
     hidden: true
@@ -363,8 +371,9 @@ resources:
         str_replace:
           params:
             '%ZONE%': {get_param: domain_name}
-            '%DNS_SERVER%': {get_param: [dns_servers, 0]}
+            '%DNS_UPDATE_MASTER%': {get_param: dns_update_master}
             '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
+            '%DNS_UPDATE_KEYNAME%': {get_param: dns_update_keyname}
             '%IP_ADDRESS%': {get_param: floatingip}
           template: {get_file: fragments/add_dns_record.sh}
 
@@ -376,8 +385,9 @@ resources:
           params:
             '%DNS_ENTRY%': {list_join: ["", ["*.", {get_param: app_subdomain}]]}
             '%ZONE%': {get_param: domain_name}
-            '%DNS_SERVER%': {get_param: [dns_servers, 0]}
+            '%DNS_UPDATE_MASTER%': {get_param: dns_update_master}
             '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
+            '%DNS_UPDATE_KEYNAME%': {get_param: dns_update_keyname}
             '%IP_ADDRESS%': {get_param: floatingip}
           template: {get_file: fragments/add_dns_record.sh}
 

--- a/loadbalancer_external.yaml
+++ b/loadbalancer_external.yaml
@@ -166,6 +166,14 @@ parameters:
     type: comma_delimited_list
     description: address of dns nameservers reachable in your environment
 
+  dns_update_master:
+    type: string
+    hidden: true
+
+  dns_update_keyname:
+    type: string
+    hidden: true
+
   dns_update_key:
     type: string
     hidden: true

--- a/loadbalancer_neutron.yaml
+++ b/loadbalancer_neutron.yaml
@@ -159,6 +159,11 @@ parameters:
     type: comma_delimited_list
     description: address of dns nameservers reachable in your environment
 
+  dns_update_master:
+    type: string
+    description: >
+      The DNS server to use for dns updates (can be an hidden master)
+
   dns_update_key:
     type: string
     hidden: true

--- a/loadbalancer_none.yaml
+++ b/loadbalancer_none.yaml
@@ -170,9 +170,20 @@ parameters:
     type: comma_delimited_list
     description: address of dns nameservers reachable in your environment
 
+  dns_update_master:
+    type: string
+    description: >
+      The DNS server to use for dns updates (can be an hidden master)
+
+  dns_update_keyname:
+    type: string
+    description: >
+      Name of the DNS key to use
+
   dns_update_key:
     type: string
-    hidden: true
+    description: >
+      DNS Key value
 
   ca_cert:
     type: string

--- a/master.yaml
+++ b/master.yaml
@@ -217,6 +217,14 @@ parameters:
     type: comma_delimited_list
     description: address of dns nameservers reachable in your environment
 
+  dns_update_master:
+    type: string
+    hidden: true
+
+  dns_update_keyname:
+    type: string
+    hidden: true
+
   dns_update_key:
     type: string
     hidden: true
@@ -419,8 +427,9 @@ resources:
         str_replace:
           params:
             '%ZONE%': {get_param: domain_name}
-            '%DNS_SERVER%': {get_param: [dns_servers, 0]}
+            '%DNS_UPDATE_MASTER%': {get_param: dns_update_master}
             '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
+            '%DNS_UPDATE_KEYNAME%': {get_param: dns_update_keyname}
             '%IP_ADDRESS%': {get_attr: [port, fixed_ips, 0, ip_address]}
           template: {get_file: fragments/add_dns_record.sh}
 

--- a/node.yaml
+++ b/node.yaml
@@ -336,9 +336,20 @@ parameters:
     type: comma_delimited_list
     description: address of dns nameservers reachable in your environment
 
+  dns_update_master:
+    type: string
+    description: >
+      The DNS server to use for dns updates (can be an hidden master)
+
+  dns_update_keyname:
+    type: string
+    description: >
+      Name of the DNS key to use
+
   dns_update_key:
     type: string
-    hidden: true
+    description: >
+      DNS Key value
 
   router_vip:
     description: >
@@ -547,8 +558,9 @@ resources:
         str_replace:
           params:
             '%ZONE%': {get_param: domain_name}
-            '%DNS_SERVER%': {get_param: [dns_servers, 0]}
+            '%DNS_UPDATE_MASTER%': {get_param: dns_update_master}
             '%DNS_UPDATE_KEY%': {get_param: dns_update_key}
+            '%DNS_UPDATE_KEYNAME%': {get_param: dns_update_keyname}
             '%IP_ADDRESS%': {get_attr: [port, fixed_ips, 0, ip_address]}
           template: {get_file: fragments/add_dns_record.sh}
 

--- a/openshift.yaml
+++ b/openshift.yaml
@@ -137,6 +137,16 @@ parameters:
       These will be configured into the OpenStack networks. They are the
       namservers that new OpenShift instances will use.
 
+  dns_update_master:
+    type: string
+    description: >
+      The DNS server to use for dns updates (can be an hidden master)
+
+  dns_update_keyname:
+    type: string
+    description: >
+      Name of the DNS key to use
+
   dns_update_key:
     type: string
     description: >
@@ -505,6 +515,11 @@ parameters:
     description: Certificate Authority Certificate to be added to trust chain
     default: ''
 
+conditions:
+
+  # Update specific dns server, or first used dns 
+  default_dns : {equals: [{get_param: dns_update_master}, ""]}
+
 resources:
 
   # Network Components
@@ -638,7 +653,9 @@ resources:
           extra_repository_urls: {get_param: extra_repository_urls}
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
           dns_servers: {get_param: dns_nameserver}
+          dns_update_master: {if: ["default_dns",get_param: [dns_servers, 0],get_param: dns_update_master]}
           dns_update_key: {get_param: dns_update_key}
+          dns_update_keyname: {get_param: dns_update_keyname}
           ca_cert: {get_param: ca_cert}
 
   openshift_infra_nodes:
@@ -683,7 +700,9 @@ resources:
           extra_repository_urls: {get_param: extra_repository_urls}
           extra_docker_repository_urls: {get_param: extra_docker_repository_urls}
           dns_servers: {get_param: dns_nameserver}
+          dns_update_master: {if: ["default_dns",get_param: [dns_servers, 0],get_param: dns_update_master]}
           dns_update_key: {get_param: dns_update_key}
+          dns_update_keyname: {get_param: dns_update_keyname}
           ca_cert: {get_param: ca_cert}
 
   openshift_nodes:
@@ -755,7 +774,9 @@ resources:
           os_region_name: {get_param: os_region_name}
           loadbalancer_type: {get_param: loadbalancer_type}
           dns_servers: {get_param: dns_nameserver}
+          dns_update_master: {if: ["default_dns",get_param: [dns_servers, 0],get_param: dns_update_master]}
           dns_update_key: {get_param: dns_update_key}
+          dns_update_keyname: {get_param: dns_update_keyname}
           lb_ip: {get_attr: [lb_floating_ip, floating_ip_address]}
           master_ip: {get_attr: [openshift_masters, resource.0.ip_address]}
           lb_hostname: {get_attr: [loadbalancer, hostname]}
@@ -1023,7 +1044,9 @@ resources:
       stack_name: {get_param: 'OS::stack_name'}
       bastion_node: {get_attr: [bastion_host, resource.host]}
       dns_servers: {get_param: dns_nameserver}
+      dns_update_master: {if: ["default_dns",get_param: [dns_servers, 0],get_param: dns_update_master]}
       dns_update_key: {get_param: dns_update_key}
+      dns_update_keyname: {get_param: dns_update_keyname}
       ca_cert: {get_param: ca_cert}
 
 outputs:


### PR DESCRIPTION
allow to specify the dns master server to use (default to first of dns_servers)
allow to specify the dns update key name (default to update-key)

there are many uses cases : 
- For example the DNS that you use to resolve are not the authoritative DNS for the zone that you want to update.
- Or also if the first DNS in resolv.conf is the nearest one (for shorter latency), and not the master.

For the keyname, "update-key" is the hardcoded value in fragments/update_dns.py and in osp-dns ( https://github.com/openshift/openshift-ansible-contrib/blob/master/reference-architecture/osp-dns/ansible/templates/update.key.j2 ) but for production servers there is not only one key.